### PR TITLE
Update changelog for PR #32, release as 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.2]
+## [0.1.0] - 2026-06-17
 
 ### Added
 
+- GPU support for DEER-based parallel sampling, including a dedicated guide
+  (`docs/src/15-gpu.md`) and a Bayesian logistic-regression GPU example.
+- `EnzymeExt` extension providing backend-specific reverse-mode Enzyme rules
+  for the `pmcmc_*` wrappers, which work around the CUDA gc-transition abort
+  Enzyme hits when differentiating matmul/reductions on GPU.
+- Exported `pmcmc_matmul`, `pmcmc_dot`, and `pmcmc_dotsum` — `Base`-equivalent
+  wrappers with stable function identities so the `EnzymeExt` AD rules fire.
+  Use these in model code that must run Enzyme on GPU.
+- Per-backend HVP strategy dispatch (`ForwardOnGrad` / `ReverseOnGrad`):
+  forward-on-gradient for forward-capable backends (`AutoEnzyme`,
+  `AutoForwardDiff`, forward Mooncake) and reverse-on-gradient routing for
+  `AutoMooncake`, `AutoZygote`, `AutoReverseDiff`, and `AutoTracker`.
 - DynamicPPL-backed `DensityModel`s now map samples back to the original
   (possibly constrained) parameter space, with names taken directly from the
   Turing model. This works correctly for distributions whose dimension changes
@@ -20,9 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `:loglikelihood` as separate columns.
 - `hvp` keyword argument is now forwarded through the `LogDensityProblems`-based
   `DensityModel` constructor.
+- Test coverage for GPU AD-HVP, GPU MALA, GPU performance, owned-matmul AD
+  rules, and a Zygote backend.
 
 ### Changed
 
+- `DifferentiationInterface` is now the single user-facing entry point into AD.
+  Backends are passed as `ADTypes` AD types and HVP routing is resolved
+  statically via singleton-trait dispatch, making the AD-HVP fallback
+  type-stable.
+- Enzyme is now an optional dependency loaded through `EnzymeExt` rather than a
+  hard dependency; `Enzyme` compat bumped to `0.13.146`.
 - `DynamicPPL` compat bumped to `0.40.6, 0.41`.
 - Parameter names for Turing models are now derived by reevaluating the model
   via `DynamicPPL.ParamsWithStats` rather than extracted heuristically at
@@ -35,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `DEER.DEFAULT_BACKEND` / `DEFAULT_HVP_BACKEND` and the old default-Enzyme
+  machinery. **`backend` is now a required keyword argument on
+  `ParallelMALASampler`** — there is no implicit default. To reproduce the
+  previous behaviour, load `Enzyme` and pass
+  `backend=AutoEnzyme(; mode=Enzyme.Forward, function_annotation=Enzyme.Duplicated)`.
 - Heuristic prior-based parameter-name extraction (`_try_extract_param_names`)
   and its warning fallback for dimension-changing bijectors.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParallelMCMC"
 uuid = "1a970f40-4406-51c9-a967-cb3143c111e8"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["Ryan Senne <rsenne@bu.edu>"]
 
 [deps]


### PR DESCRIPTION
Documents PR #32 in the changelog and relabels the unreleased version from 0.0.2 to 0.1.0 (0.0.2 was never released; PR #32 included breaking changes plus new GPU/AD features).