### PR TITLE
Use [sources] in docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,3 @@
-# Don't forget to run
-#
-#     pkg> dev ..
-#
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
@@ -9,3 +5,6 @@ ParallelMCMC = "1a970f40-4406-51c9-a967-cb3143c111e8"
 
 [compat]
 Documenter = "1"
+
+[sources]
+ParallelMCMC = {path = "../"}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,8 +3,8 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 ParallelMCMC = "1a970f40-4406-51c9-a967-cb3143c111e8"
 
+[sources]
+ParallelMCMC = {path = ".."}
+
 [compat]
 Documenter = "1"
-
-[sources]
-ParallelMCMC = {path = "../"}


### PR DESCRIPTION
Then you don't have to `]dev ..` anymore. The caveat is that this only works on 1.11+, but that's probably fine for docs since you're probably only ever building docs on one version of Julia.