### PR TITLE
Make CUDA a package extension

### DIFF
--- a/.github/workflows/TestOnPRs.yml
+++ b/.github/workflows/TestOnPRs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "src/**"
+      - "ext/**"
       - "test/**"
       - "*.toml"
     types: [opened, synchronize, reopened]

--- a/.github/workflows/TestReactant.yml
+++ b/.github/workflows/TestReactant.yml
@@ -1,0 +1,66 @@
+name: Test Reactant
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "ext/ReactantExt.jl"
+      - "test/test-Reactant-*.jl"
+      - "Project.toml"
+      - "test/Project.toml"
+      - ".github/workflows/TestReactant.yml"
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+permissions:
+  contents: read
+
+jobs:
+  reactant:
+    name: Reactant HVP - Julia 1 - ubuntu-latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    env:
+      PARALLELMCMC_TEST_REACTANT: "true"
+      JULIA_NUM_PRECOMPILE_TASKS: "2"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1"
+          arch: x64
+
+      # Caches Reactant_jll alongside the compiled packages between runs.
+      - name: Use Julia cache
+        uses: julia-actions/cache@v3
+
+      - name: Instantiate test environment with Reactant
+        run: |
+          julia --project=test -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.add("Reactant")
+            Pkg.instantiate()
+            Pkg.status()
+          '
+
+      - name: Run Reactant tests
+        run: |
+          julia --project=test -e '
+            using Test
+            @testset verbose=true "Reactant" begin
+                include("test/test-Reactant-Validation.jl")
+                include("test/test-Reactant-HVP.jl")
+            end
+          '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CUDA is now a weak dependency behind a `CUDAExt` extension, so installing and
+  loading ParallelMCMC no longer drags in the CUDA stack on machines that cannot
+  use it (#59). GPU runs are unchanged apart from needing `using CUDA` alongside
+  `using ParallelMCMC`, which they already did to build the `CuArray`s.
+  The samplers were array-type-agnostic everywhere but the random fills — MALA's
+  normal noise and DEER's Rademacher probes, which cannot be written into device
+  memory one element at a time. Those now ask
+  `ParallelMCMC.needs_host_staging(x)` whether to stage through a host buffer;
+  the extension is the one method answering `true` for `CuArray`, and another
+  device array type is one method away.
 - The AD-HVP fallback strategy (forward-on-grad vs reverse-on-grad) now comes
   from DifferentiationInterface's `hvp_mode` trait rather than a hardcoded
   per-backend list, so `AutoEnzyme(mode=Enzyme.Reverse)` routes to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,103 +10,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The derivative slots of `DensityModel` (`grad_logdensity`, `hvp`,
-  `grad_logdensity_batch`, `hvp_batch`) now take an `ADTypes.AbstractADType`
-  in place of a callable, so `DensityModel(logp, AutoForwardDiff(), dim)`
-  builds a model from the log-density alone. Backends are turned into
-  prepared DifferentiationInterface callables when sampling starts, and that
-  preparation is reused across steps (#40, #52). The prepared model rides
-  along in the sampler state to get that reuse; a state handed to `step` for a
-  different model, which `initial_state` allows, is re-prepared from the model
-  passed rather than reused, so the model given to `sample` is the one sampled.
-- `ParallelMALASampler`'s `backend` keyword is now optional. It is only the
-  fallback source of Hessian-vector products, so a `DensityModel` carrying
-  its own `hvp` / `hvp_batch` does not need it (#52). With no sampler
-  `backend`, a batched HVP is derived from the model's own `hvp` backend.
-- A `logdensity_batch` given without a `grad_logdensity_batch` now has the
-  batched gradient derived for it when `grad_logdensity` is a backend, rather
-  than leaving the batched DEER path switched off (#52). `hvp_batch` can be a
-  backend in that case too, and differentiates the derived gradient.
-- An HVP backend over an AD-derived gradient is now taken as true second-order
-  AD, `DifferentiationInterface.SecondOrder(hvp_backend, grad_backend)` handed
-  to `DI.hvp`, instead of an outer AD pass over the prepared DI gradient (#37).
-  That nesting dropped out of its preparation as soon as the outer pass pushed
-  tangents in, so the composed operator is both what was asked for and cheaper:
-  around 10x fewer allocations for a `logdensity`-only model. A backend over a
-  hand-written gradient still differentiates that gradient once, as before.
-- `hvp` / `hvp_batch` accept a `SecondOrder` with both halves honoured, meaning
-  the log-density is differentiated twice and the gradient slot is not the inner
-  pass. Previously the inner half was silently discarded and only the outer used.
-  This is the one AD route to an HVP for a Turing or LogDensityProblems model,
-  whose gradient arrives already prepared and so cannot be differentiated again.
+  `grad_logdensity_batch`, `hvp_batch`) now also accept
+  `ADTypes.AbstractADType`. AD preparations are cached per model (#40, #52).
+- `ParallelMALASampler`'s `backend` is optional when the model supplies its
+  own HVPs (#52).
+- Batched gradients are derived from `logdensity_batch` when
+  `grad_logdensity` is a backend (#52).
+- HVP backends over AD-derived gradients now use
+  `DifferentiationInterface.SecondOrder`; explicit `SecondOrder` backends
+  respect both configured passes (#37).
+- `ADTypes.AutoReactant()` can supply derivatives and sampler HVPs through
+  Reactant.jl. It requires `using Reactant`, a traceable log-density, and
+  `AutoReactant()` on both AD passes of an HVP (#37, #52).
 - The `DensityModel` constructors in `DynamicPPLExt` and `LogDensityProblemsExt`
-  forward `logdensity_batch`, `grad_logdensity_batch` and `hvp_batch`, so a
-  Turing or LogDensityProblems model can reach the batched DEER path. Neither
-  provides a batched log-density, so `logdensity_batch` has to be written by hand.
-- Adds `JuliaFormatter` testing which was forgotten (#60).
+  now accept `hvp` and the batched derivative slots.
 
 ### Fixed
 
-- The reverse-on-grad HVP path differentiated with `DI.inner(backend)` while
-  its strategy was routed on `DI.outer(backend)`, so a
-  `DifferentiationInterface.SecondOrder` ran the wrong half of the pair. A
-  `SecondOrder` now goes to the true second-order path instead of either
-  strategy, and the half-selecting helper it still uses agrees: normalization
-  applies to the outer pass. Unwrapping to that half happens before the
-  normalization hook is dispatched on, so a `SecondOrder(AutoEnzyme(), ...)` still
-  reaches `EnzymeExt` and gets its function annotation filled in rather than
-  running as a bare `AutoEnzyme()`.
+- `SecondOrder` now respects both configured backends.
 - Backend normalization no longer picks a differentiation mode on the user's
-  behalf (#62). `EnzymeExt` pinned `mode=Enzyme.Forward` (with
-  `set_runtime_activity`) onto an `AutoEnzyme()` left mode-agnostic, on the
-  grounds that reverse mode hit a gc-transition abort on GPU and that composed
-  `pmcmc_matmul` calls needed runtime activity. The `pmcmc_*` Enzyme rules keep
-  Enzyme off both paths on their own now, so the pin bought nothing — and it cost
-  correctness, because it silently rewrote the direction of a `SecondOrder`'s
-  outer half. `SecondOrder(AutoEnzyme(), AutoForwardDiff())` is
-  reverse-over-forward to `hvp_mode`, its inner half being forward-only, and came
-  out forward-over-forward. Normalization now fills in only
-  `function_annotation=Enzyme.Const`, which is about this package's own read-only
-  HVP wrappers rather than about Enzyme's mode, and leaves `mode` exactly as given
-  — unset included, for DI to resolve from the operator it runs. `hvp_mode` is
-  therefore identical before and after normalization for every backend pair.
-
-  A mode set explicitly was never overridden, so only mode-agnostic backends were
-  affected, and the HVP was a correct HVP either way; what changes is that the
-  composition asked for is the one that runs. The two normalization hooks
-  (`_hvp_forward_backend`, `_hvp_closure_backend`) collapse into a single
-  `_normalized_backend`, since without a mode to choose they no longer differ.
-  Users relying on a plain `AutoEnzyme()` being run forward should now pass
-  `AutoEnzyme(; mode=Enzyme.Forward)` explicitly.
+  behalf (#62). `AutoEnzyme()` keeps its unset mode. Pass
+  `AutoEnzyme(; mode=Enzyme.Forward)` to request forward mode explicitly.
+- Invalid `AutoReactant` backend combinations are rejected before compilation.
 
 ### Changed
 
-- The AD-HVP fallback strategy (forward-on-grad vs reverse-on-grad) now comes
-  from DifferentiationInterface's `hvp_mode` trait rather than a hardcoded
-  per-backend list, so `AutoEnzyme(mode=Enzyme.Reverse)` routes to the
-  reverse-on-grad path (#38).
-- Because a `logdensity_batch` without a `grad_logdensity_batch` now has the
-  batched gradient derived rather than switching the batched DEER path off, a
-  model whose `grad_logdensity` is a backend runs the batched update where it
-  used to run the unbatched one, and AD is applied to its `logdensity_batch`. On
-  GPU that subjects a function nothing was differentiating before to the
-  backend's restrictions (`pmcmc_*` wrappers for Enzyme). Supply
-  `grad_logdensity_batch` to keep AD out of the batched path. A model with a
-  hand-written `grad_logdensity` is unaffected: nothing derives a batched
-  gradient for it, so the batched path stays off as before.
+- The AD-HVP fallback now respects the backend's `hvp_mode`, so
+  `AutoEnzyme(mode=Enzyme.Reverse)` uses reverse-on-grad (#38).
+- Deriving a batched gradient applies AD to `logdensity_batch`. Supply
+  `grad_logdensity_batch` to avoid this.
 - `ParallelMALASampler`'s `backend` no longer derives a batched gradient, only
-  Hessian-vector products. It could previously switch the batched DEER path on
-  for a model with a hand-written gradient, which made a keyword that reads as
-  an HVP fallback decide which update path ran and put AD on a
-  `logdensity_batch` the user had not opted into differentiating. Models that
-  relied on that should pass `grad_logdensity_batch` explicitly, or a backend in
-  `grad_logdensity` for one to be derived from.
-- Both batched derivative slots now require `logdensity_batch`, which the
-  batched update evaluates directly, and the constructor rejects them without
-  one. A callable `grad_logdensity_batch` or `hvp_batch` supplied on its own
-  used to be accepted and then silently ignored. `logdensity_batch` alone is
-  still valid and still used to score whole trajectories.
-- An `hvp_batch` that reaches sampling with no batched gradient to pair it with
-  now raises rather than silently falling back to the unbatched update.
+  Hessian-vector products. Pass `grad_logdensity_batch` explicitly or use a
+  backend in `grad_logdensity` to derive one.
+- Batched derivative slots require `logdensity_batch`. An `hvp_batch` without
+  a batched gradient now raises an error.
 
 ### Removed
 

--- a/Project.toml
+++ b/Project.toml
@@ -20,12 +20,14 @@ Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
 DynamicPPLExt = ["DynamicPPL", "FlexiChains", "LogDensityProblems"]
 EnzymeExt = "Enzyme"
 LogDensityProblemsExt = "LogDensityProblems"
+ReactantExt = ["Reactant", "Enzyme"]
 
 [compat]
 ADTypes = "1.21.0"
@@ -42,6 +44,7 @@ LogDensityProblems = "2"
 Mooncake = "0.5.26"
 OrderedCollections = "1"
 Random = "1"
+Reactant = "0.2.278"
 Statistics = "1"
 Zygote = "0.7.10"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ authors = ["Ryan Senne <rsenne@bu.edu>"]
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FlexiChains = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -15,6 +14,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -23,6 +23,7 @@ Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
+CUDAExt = "CUDA"
 DynamicPPLExt = ["DynamicPPL", "FlexiChains", "LogDensityProblems"]
 EnzymeExt = "Enzyme"
 LogDensityProblemsExt = "LogDensityProblems"

--- a/docs/src/10-getting-started.md
+++ b/docs/src/10-getting-started.md
@@ -31,13 +31,13 @@ model = DensityModel(logp, grad_logp, 2; param_names=[:x1, :x2])
 
 ### AD backends in derivative slots
 
-Any of the derivative slots (`grad_logdensity`, `hvp`, `grad_logdensity_batch`, `hvp_batch`) can be given an `ADTypes.AbstractADType` instead of a callable, in which case that derivative is taken with AD.  A model can therefore be written with nothing but the log-density:
+Derivative slots (`grad_logdensity`, `hvp`, `grad_logdensity_batch`, and `hvp_batch`) accept callables or `ADTypes.AbstractADType` backends. This is enough to build a model from only its log-density:
 
 ```julia
 model = DensityModel(logp, AutoEnzyme(), 2; param_names=[:x1, :x2])
 ```
 
-Backends become prepared [DifferentiationInterface](https://github.com/JuliaDiff/DifferentiationInterface.jl) callables when sampling starts, and that preparation is reused for the rest of the run.  Hand-written and AD-derived slots mix, so an analytical gradient with `hvp=AutoForwardDiff()` works.
+Hand-written and AD-derived slots can be mixed.
 
 ### What a backend in `hvp` differentiates
 
@@ -47,13 +47,13 @@ Backends become prepared [DifferentiationInterface](https://github.com/JuliaDiff
 | backend | backend | `SecondOrder(hvp, grad_logdensity)` on `logdensity` |
 | either | `SecondOrder(...)` | that pair on `logdensity`, gradient slot unused |
 
-Naming both passes yourself is the one route that ignores the gradient slot, hand-written or not.  It is also the only AD route to an HVP for a Turing or LogDensityProblems model, whose gradient arrives already prepared and cannot be differentiated again.
+An explicit `SecondOrder` bypasses the gradient slot. Use it for an AD-derived HVP on Turing or LogDensityProblems models.
 
-Which pairs work is up to the backends.  On CPU, ForwardDiff, ReverseDiff, Zygote and Enzyme all serve a log-density-only model.  `AutoMooncake` serves neither direction: it has no reverse-over-reverse, and its gradient rejects an outer pass's tangents.  Give Mooncake a hand-written `grad_logdensity` instead.  No second-order pair works on GPU yet (see [#37](https://github.com/rsenne/ParallelMCMC.jl/issues/37) and the [GPU page](15-gpu.md)).
+See [GPU Execution](15-gpu.md) for backend compatibility.
 
-The batched pair works the same way, on `sum(logdensity_batch(X))`.  That sum's gradient is the stacked per-column gradients only because the columns are independent, so `logdensity_batch` must not couple them.  Omitting `grad_logdensity_batch` derives one when `grad_logdensity` is a backend; with a hand-written gradient the batched path stays off and the unbatched update covers it.  Both batched derivative slots require `logdensity_batch`, which is also useful on its own for scoring a whole trajectory at once.
+The batched pair differentiates `sum(logdensity_batch(X))`, so each output must depend only on the corresponding column of `X`. When `grad_logdensity` is a backend, omitting `grad_logdensity_batch` derives it automatically. Both batched derivative slots require `logdensity_batch`.
 
-`backend` on [`ParallelMALASampler`](@ref) supplies Hessian-vector products for a model that brings no `hvp` / `hvp_batch` of its own, and nothing else.  A model carrying its own can leave it out.
+[`ParallelMALASampler`](@ref)'s `backend` supplies missing HVPs. Omit it when the model supplies them.
 
 ---
 

--- a/docs/src/15-gpu.md
+++ b/docs/src/15-gpu.md
@@ -2,6 +2,8 @@
 
 DEER's prefix-scan and per-step batch evaluations are array-type-agnostic, so the same `ParallelMALASampler` runs on either CPU or GPU.  This page covers when GPU pays off, the current limitations, and a worked example.
 
+ParallelMCMC does not depend on CUDA.jl.  Run `using CUDA` alongside `using ParallelMCMC` and the `CUDAExt` extension loads, after which the samplers accept `CuArray` parameters; without it the package is CPU-only and never pays CUDA's load cost.
+
 ---
 
 ## When to use GPU
@@ -99,7 +101,7 @@ so neither the positive nor negative tail overflows in `Float32`.
 ### Synthetic data
 
 ```julia
-using Random, CUDA
+using ParallelMCMC, Random, CUDA   # `using CUDA` is what loads ParallelMCMC's CUDAExt
 
 D = 50; N = 1000
 rng    = MersenneTwister(0)

--- a/docs/src/15-gpu.md
+++ b/docs/src/15-gpu.md
@@ -232,11 +232,28 @@ DEER needs a Hessian–vector product $H v$ at every Newton step.  `DensityModel
 - **You supply `hvp` / `hvp_batch`.**  These run as plain kernels.  The AD backend is never invoked for HVPs.
 - **You only supply `gradlogp` / `grad_logdensity_batch`.**  The sampler builds the HVP by differentiating your gradient — either a forward-mode pushforward of `gradlogp` ([`ForwardOnGrad`](https://github.com/rsenne/ParallelMCMC.jl/blob/main/src/DEER/DEER.jl), the default for most backends) or a reverse-mode gradient of `x -> dot(gradlogp(x), v)` ([`ReverseOnGrad`](https://github.com/rsenne/ParallelMCMC.jl/blob/main/src/DEER/DEER.jl), used for `AutoMooncake` and `AutoZygote`).  This is the **AD-HVP fallback**, and it is what the logistic-regression example above uses.
 
-!!! warning "Log-density-only models on GPU"
-    `grad_logdensity` can itself be an AD backend (`DensityModel(logp, AutoEnzyme(), dim)`, see [Getting started](10-getting-started.md)), but don't do that with `ParallelMALASampler` on GPU.  The HVP becomes `SecondOrder(hvp_backend, grad_backend)` on your log-density, which currently fails on GPU with both Enzyme and Mooncake (see [#37](https://github.com/rsenne/ParallelMCMC.jl/issues/37)).  The same goes for passing a `SecondOrder` explicitly.  Write `gradlogp` out by hand for DEER, so the HVP is a single pass over it.  The sequential samplers only need the gradient, so log-density-only models work there.
-
 !!! note "A backend in `grad_logdensity` reaches `logdensity_batch` too"
     The batched path needs a batched gradient, and derives one from `logdensity_batch` when `grad_logdensity` is a backend.  That puts `logdensity_batch` under the same restrictions as the rest of your AD-visible code.  Supply `grad_logdensity_batch` to avoid it.
+
+### Reactant HVPs
+
+`ADTypes.AutoReactant()` provides a compiled HVP path through [Reactant.jl](https://github.com/EnzymeAD/Reactant.jl). Load Reactant before preparing the model:
+
+```julia
+using Reactant, ADTypes
+
+model = DensityModel(logp, AutoReactant(), D)
+sampler = ParallelMALASampler(0.005f0; T=16, backend=AutoReactant())
+```
+
+!!! warning "Reactant constraints"
+    **Captured arrays are frozen at compile time.** Mutating them after preparation does not change the compiled derivative. Pass mutable data as an argument.
+
+    **Reactant chooses the execution device independently of the input array.** With Reactant's CPU client, `CuArray` inputs round-trip through the host. The sampler warns about this when it prepares the model. Select a GPU client with `Reactant.set_default_backend` when available.
+
+- The log-density must be Reactant-traceable. DynamicPPL-built log-densities are not.
+- Across an HVP's two AD passes, use `AutoReactant()` for both or neither. A hand-written gradient may pair with it. `SecondOrder` cannot contain `AutoReactant()`.
+- Only the default `AutoReactant()` mode is supported.
 
 ### When the fallback is the right call
 
@@ -287,7 +304,6 @@ model = DensityModel(logp, gradlogp, D;
                      grad_logdensity_batch=gradlogp_batch,
                      hvp=hvp, hvp_batch=hvp_batch)
 
-# The model supplies its own HVPs, so no `backend` is needed.
 sampler = ParallelMALASampler(0.005f0; T=16, damping=0.5f0)
 ```
 

--- a/docs/src/95-reference.md
+++ b/docs/src/95-reference.md
@@ -6,6 +6,25 @@ CurrentModule = ParallelMCMC
 
 This page documents all public types and functions exported by ParallelMCMC.jl.
 
+## CUDA and other device arrays
+
+CUDA is not a dependency of ParallelMCMC. `using CUDA` loads the `CUDAExt`
+extension, which is all it takes for the samplers to accept `CuArray`
+parameters — see [GPU Execution](15-gpu.md).
+
+The extension sets one method. Everything the samplers do to a device array
+goes through the generic `AbstractArray` interface, except the random fills,
+which cannot write into device memory one element at a time and stage through a
+host buffer instead. Another array type joins by answering the same question:
+
+```julia
+ParallelMCMC.needs_host_staging(::ROCArray) = true
+```
+
+```@docs
+ParallelMCMC.needs_host_staging
+```
+
 ## Extension constructors
 
 `DensityModel` also has extension constructors for common probabilistic-programming interfaces:

--- a/docs/src/95-reference.md
+++ b/docs/src/95-reference.md
@@ -6,6 +6,12 @@ CurrentModule = ParallelMCMC
 
 This page documents all public types and functions exported by ParallelMCMC.jl.
 
+## Reactant
+
+Loading `Reactant` (`using Reactant`) enables `ADTypes.AutoReactant()` as a
+derivative-slot backend on `DensityModel` and as `ParallelMALASampler`'s
+`backend`. See [GPU Execution](15-gpu.md) for its constraints.
+
 ## Extension constructors
 
 `DensityModel` also has extension constructors for common probabilistic-programming interfaces:

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -1,0 +1,15 @@
+module CUDAExt
+
+#=
+CUDA's only job in ParallelMCMC is telling the random fills that a `CuArray`
+cannot be written element by element. Everything else the samplers do to a
+device array — `similar`, broadcast, `copyto!`, the affine scan — goes through
+the generic `AbstractArray` interface, so no other method is needed here.
+=#
+
+using ParallelMCMC: ParallelMCMC
+using CUDA: CuArray
+
+ParallelMCMC.needs_host_staging(::CuArray) = true
+
+end

--- a/ext/DynamicPPLExt.jl
+++ b/ext/DynamicPPLExt.jl
@@ -18,17 +18,10 @@ computation via DynamicPPL's `adtype` interface.
 Requires `DynamicPPL` and `LogDensityProblems` to be loaded (these are the weak-dependency
 triggers for this extension), plus any AD backend that is used.
 
-`ad_backend` is DynamicPPL's own `adtype`, not a `DensityModel` slot: it goes to
-the `LogDensityFunction` that fills the log-density and gradient slots, which is
-why it takes a backend only and never a callable. The rest are `DensityModel`
-slots forwarded unchanged.
-
-`ParallelMALASampler` also needs an HVP. Give it a callable or a
-`DifferentiationInterface.SecondOrder`, which differentiates the log-density and
-so bypasses DynamicPPL's gradient. A plain backend fails, since it would
-differentiate the gradient `ad_backend` produced and that preparation rejects an
-outer pass's tangents. DynamicPPL supplies no batched log-density either, so
-reaching the batched DEER path means writing `logdensity_batch` by hand.
+`ad_backend` configures DynamicPPL's `LogDensityFunction`. The remaining
+keywords are forwarded to `DensityModel`. HVPs require a callable or explicit
+`DifferentiationInterface.SecondOrder`; plain HVP backends are unsupported.
+Batched derivatives require a hand-written `logdensity_batch`.
 
 # Example
 ```julia
@@ -52,14 +45,12 @@ function ParallelMCMC.DensityModel(
     grad_logdensity_batch=nothing,
     hvp_batch=nothing,
 )
-    # Sample in linked/unconstrained space and let DynamicPPL provide the gradient.
     ld = DynamicPPL.LogDensityFunction(
         turing_model,
         DynamicPPL.getlogjoint_internal,
         DynamicPPL.LinkAll();
         adtype=ad_backend,
     )
-    # Requires LogDensityProblemsExt to be loaded
     return ParallelMCMC.DensityModel(
         ld;
         hvp=hvp,

--- a/ext/EnzymeExt.jl
+++ b/ext/EnzymeExt.jl
@@ -19,24 +19,7 @@ using Enzyme.EnzymeCore.EnzymeRules:
 
 # TODO: Implement matmul overloads upstream in Enzyme. See: https://github.com/EnzymeAD/Enzyme.jl/issues/3122
 
-#=
-Normalization of the user's `AutoEnzyme` for DEER's AD-HVP paths: fill in
-`function_annotation=Enzyme.Const` when they left it open, so Enzyme doesn't
-throw `EnzymeMutabilityException` on the read-only `_HvpReverseClosure` /
-`_BatchHvpReverseClosure` wrappers, which capture `gradlogp`. Those wrapper types
-belong to this package, so declaring them constant is this package's business.
-
-`mode` is passed through exactly as given, unset included. Choosing a direction
-on the user's behalf is not our call: a mode they set is a decision, and an unset
-one is DI's to resolve from the operator it runs.
-
-An earlier version pinned `mode=Enzyme.Forward` here (with
-`set_runtime_activity`) against the gc-transition abort on GPU and
-`EnzymeRuntimeActivityError` on composed `pmcmc_matmul` calls. The rules below
-keep Enzyme off both paths on their own, so the pin bought nothing and cost
-correctness: it silently rewrote the direction of a `SecondOrder`'s outer half
-(see `DEER._normalized_backend`).
-=#
+# Add the default function annotation without changing the user's mode.
 function DEER._normalized_backend(backend::ADTypes.AutoEnzyme{M,A}) where {M,A}
     A === Nothing || return backend
     return ADTypes.AutoEnzyme(; mode=backend.mode, function_annotation=Enzyme.Const)

--- a/ext/LogDensityProblemsExt.jl
+++ b/ext/LogDensityProblemsExt.jl
@@ -20,15 +20,10 @@ The optional `param_names` keyword accepts a collection of parameter names that 
 for the columns of the returned `FlexiChain` object. If omitted, a single vector-valued
 parameter named `:x` will be chosen, unless you also pass `param_names` to `sample(...)`.
 
-`hvp` and the batched slots are forwarded to the main `DensityModel` constructor
-and keep their meaning there, with one caveat. `ld` fills the gradient slot, and
-a gradient `ld` computes by AD carries a preparation tied to its input type, so
-it rejects the tangents a plain `hvp` backend would push through it. Use a
-callable, or a `DifferentiationInterface.SecondOrder` which differentiates the
-log-density instead. Same for `hvp_batch`.
-
-`ld` supplies no batched log-density, so reaching the batched DEER path means
-writing `logdensity_batch` by hand.
+`hvp` and the batched slots are forwarded to `DensityModel`. Use a callable or
+explicit `DifferentiationInterface.SecondOrder` for HVPs; plain backends and
+`AutoReactant()` are unsupported. Batched derivatives require a hand-written
+`logdensity_batch`.
 
 # Turing.jl / DynamicPPL example
 ```julia

--- a/ext/ReactantExt.jl
+++ b/ext/ReactantExt.jl
@@ -1,0 +1,133 @@
+module ReactantExt
+
+# Reactant treats captured arrays as compile-time constants. Traced model
+# functions must not depend on later mutations to captured data.
+
+using ParallelMCMC: ParallelMCMC
+using ParallelMCMC.DEER: DEER
+using ADTypes: ADTypes, AutoReactant, AutoEnzyme
+using Reactant: Reactant, @compile
+using Enzyme: Enzyme
+
+_check_reactant_mode(::AutoReactant{AutoEnzyme{Nothing,Nothing}}) = nothing
+function _check_reactant_mode(backend::AutoReactant)
+    return throw(
+        ArgumentError(
+            "AutoReactant mode $(backend.mode) is not supported; use AutoReactant()"
+        ),
+    )
+end
+
+function _reactant_client_platform()
+    return string(Reactant.XLA.platform_name(Reactant.XLA.default_backend()))
+end
+
+function _warn_reactant_host_roundtrip(x::AbstractArray)
+    if ParallelMCMC.needs_host_staging(x) && _reactant_client_platform() == "cpu"
+        @warn "AutoReactant: preparing on a $(typeof(x)), but Reactant's default XLA " *
+            "client targets \"cpu\". Every call will round-trip to the host and back " *
+            "instead of running where the array lives. Select a GPU client with " *
+            "`Reactant.set_default_backend(\"gpu\")` if one is available." maxlog = 1
+    end
+    return nothing
+end
+
+_host(x::Array) = x
+_host(x::AbstractArray) = Array(x)
+
+# Preserve promotions performed by the compiled function. The result is a fresh
+# array every call: callers keep gradients (tapes, workspaces), so it must not
+# alias a reused buffer.
+function _from_host(template::AbstractArray, out)
+    out_h = Array(out)
+    template isa Array && eltype(out_h) === eltype(template) && return out_h
+    res = similar(template, eltype(out_h), size(out_h))
+    copyto!(res, out_h)
+    return res
+end
+
+#=
+Reactant's `copyto!(::ConcreteRArray, ::Array)` uploads to a new buffer and
+then runs a compiled device-to-device copy into the destination, which is
+strictly more work than the upload alone.
+=#
+_upload(x::AbstractArray) = Reactant.to_rarray(_host(x))
+
+function _compiled(core, t1::AbstractArray)
+    _warn_reactant_host_roundtrip(t1)
+    compiled = @compile core(_upload(t1))
+    return x -> _from_host(x, compiled(_upload(x)))
+end
+
+function _compiled(core, t1::AbstractArray, t2::AbstractArray)
+    _warn_reactant_host_roundtrip(t1)
+    compiled = @compile core(_upload(t1), _upload(t2))
+    return (x, v) -> _from_host(x, compiled(_upload(x), _upload(v)))
+end
+
+# For g = gradlogp, this JVP is the HVP. The callable and its captures are constant.
+function _jvp(g, x, v)
+    return only(Enzyme.autodiff(Enzyme.Forward, Enzyme.Const(g), Enzyme.Duplicated(x, v)))
+end
+
+#= `Base.Fix1` only accepts trailing arguments on 1.12+; this is the same partial
+application, spelled for the 1.10 compat floor. =#
+struct JVPWith{G}
+    g::G
+end
+(c::JVPWith)(x, v) = _jvp(c.g, x, v)
+
+_rev_gradient(f, x) = Enzyme.gradient(Enzyme.Reverse, Enzyme.Const(f), x)[1]
+
+function ParallelMCMC._reactant_resolve_gradient(
+    logdensity, backend::AutoReactant, x_template::AbstractVector
+)
+    _check_reactant_mode(backend)
+    core = Base.Fix1(_rev_gradient, logdensity)
+    return _compiled(core, x_template)
+end
+
+function ParallelMCMC._reactant_resolve_gradient_batch(
+    logdensity_batch, backend::AutoReactant, X_template::AbstractMatrix
+)
+    _check_reactant_mode(backend)
+    core = Base.Fix1(_rev_gradient, ParallelMCMC._BatchLogdensitySum(logdensity_batch))
+    return _compiled(core, X_template)
+end
+
+# AD-derived gradients differentiate the log-density; callable gradients use a JVP.
+function DEER._make_hvp_fn_second_order(
+    logdensity, backend::AutoReactant, x_template::AbstractVector
+)
+    _check_reactant_mode(backend)
+    inner = Base.Fix1(_rev_gradient, logdensity)
+    core = JVPWith(inner)
+    return _compiled(core, x_template, x_template)
+end
+
+function DEER._make_hvp_fn(
+    ::DEER.ReactantHVP, gradlogp, backend::AutoReactant, x_template::AbstractVector
+)
+    _check_reactant_mode(backend)
+    core = JVPWith(gradlogp)
+    return _compiled(core, x_template, x_template)
+end
+
+function DEER._make_hvp_batch_fn_second_order(
+    logdensity_batch_sum, backend::AutoReactant, X_template::AbstractMatrix
+)
+    _check_reactant_mode(backend)
+    inner = Base.Fix1(_rev_gradient, logdensity_batch_sum)
+    core = JVPWith(inner)
+    return _compiled(core, X_template, X_template)
+end
+
+function DEER._make_hvp_batch_fn(
+    ::DEER.ReactantHVP, grad_batch, backend::AutoReactant, X_template::AbstractMatrix
+)
+    _check_reactant_mode(backend)
+    core = JVPWith(grad_batch)
+    return _compiled(core, X_template, X_template)
+end
+
+end # module

--- a/src/DEER/DEER.jl
+++ b/src/DEER/DEER.jl
@@ -4,7 +4,8 @@ using LinearAlgebra
 using DifferentiationInterface
 using ADTypes: ADTypes, AbstractADType
 using Random
-using CUDA: CUDA
+
+import ..ParallelMCMC: needs_host_staging
 
 include("DEERScan.jl")
 using .DEERScan
@@ -42,7 +43,7 @@ Reusable buffers for allocation-light DEER updates and solves.
 
 All buffers are created with the same array type / device placement as `S_template`
 (or `s0_template` for vector buffers), so the workspace is GPU-compatible when
-constructed from `CuArray` templates.
+constructed from device-array templates.
 """
 struct DEERWorkspace{M,V,SW,HZ,H}
     A::M
@@ -65,12 +66,12 @@ function DEERWorkspace(S_template::AbstractMatrix, s0_template::AbstractVector)
     B = similar(S_template)
     Xbar = similar(S_template)
     Z = similar(S_template)
-    Zhost = Z isa CUDA.CuArray ? Matrix{eltype(S_template)}(undef, size(Z)...) : nothing
+    Zhost = needs_host_staging(Z) ? Matrix{eltype(S_template)}(undef, size(Z)...) : nothing
     S_work = similar(S_template)
     S_tmp = similar(S_template)
     diff_buf = similar(S_template)
     zbuf = similar(s0_template)
-    zhost = if zbuf isa CUDA.CuArray
+    zhost = if needs_host_staging(zbuf)
         Vector{eltype(s0_template)}(undef, length(s0_template))
     else
         nothing
@@ -352,20 +353,17 @@ function _make_hvp_batch_fn_second_order(
 end
 
 @inline function _rademacher!(z::AbstractArray{T}, rng::AbstractRNG) where {T}
+    #= Unbuffered call on a device array: allocate the staging buffer for this
+    one fill. The hot paths hand over a workspace buffer instead. =#
+    needs_host_staging(z) && return _rademacher!(z, rng, Vector{T}(undef, length(z)))
     @inbounds for i in eachindex(z)
         z[i] = rand(rng, Bool) ? one(T) : -one(T)
     end
     return z
 end
 
-@inline function _rademacher!(z::CUDA.CuArray{T}, rng::AbstractRNG) where {T}
-    host = Vector{T}(undef, length(z))
-    _rademacher!(z, rng, host)
-    return z
-end
-
 @inline function _rademacher!(
-    z::CUDA.CuArray{T}, rng::AbstractRNG, host::AbstractArray{T}
+    z::AbstractArray{T}, rng::AbstractRNG, host::AbstractArray{T}
 ) where {T}
     length(host) == length(z) || throw(DimensionMismatch("host buffer must match z"))
     _rademacher!(host, rng)

--- a/src/DEER/DEER.jl
+++ b/src/DEER/DEER.jl
@@ -164,7 +164,7 @@ We bundle the closure with the prep so `prepare_gradient` and `gradient`
 see the same function instance (DI keys preparations on function identity).
 ---------------------------------------------------------------------------
 =#
-import ..ParallelMCMC: pmcmc_dot, pmcmc_dotsum
+import ..ParallelMCMC: pmcmc_dot, pmcmc_dotsum, _REACTANT_LOAD_HINT
 
 struct _HvpReverseClosure{F}
     grad::F
@@ -177,16 +177,14 @@ end
 (c::_BatchHvpReverseClosure)(X, V) = pmcmc_dotsum(c.grad_batch(X), V)
 
 #=
-Pick the AD-HVP fallback strategy from the user's backend. These two apply when
-the HVP is one AD pass over a gradient we already have, i.e., a hand-written
-`gradlogp`, which neither of them differentiates twice:
+Pick the AD-HVP fallback strategy from the user's backend. Both are one AD pass
+over a hand-written `gradlogp`; an AD-derived gradient goes to
+`_make_hvp_fn_second_order` instead.
 
   ForwardOnGrad()   — `pushforward(gradlogp, x, v)`. Routes through the
                       `pmcmc_matmul` frule.
   ReverseOnGrad()   — `gradient(x -> pmcmc_dot(gradlogp(x), v))`. Routes
                       through the matmul and dot/sum rrules.
-
-An AD-derived gradient takes neither and goes to `_make_hvp_fn_second_order`.
 
 These are singleton types rather than symbols so the choice dispatches
 statically — `_make_hvp_fn(_hvp_strategy(backend), ...)` resolves to one
@@ -203,33 +201,16 @@ abstract type HVPStrategy end
 struct ForwardOnGrad <: HVPStrategy end
 struct ReverseOnGrad <: HVPStrategy end
 
+struct ReactantHVP <: HVPStrategy end
+
 _strategy_from(::DI.ForwardOverAnything) = ForwardOnGrad()
 _strategy_from(::DI.HVPMode) = ReverseOnGrad()
 
 _hvp_strategy(backend::AbstractADType) = _strategy_from(DI.hvp_mode(backend))
+_hvp_strategy(::ADTypes.AutoReactant) = ReactantHVP()
 
-#=
-Hook for backend-specific normalization of the user's `backend`, applied on every
-AD-HVP path before the backend reaches DI.
-
-It supplies what the wrappers DEER differentiates need, and nothing else. Those
-wrapper types are ours, so annotating them is ours to do: EnzymeExt specializes
-this to fill `function_annotation=Enzyme.Const`, without which Enzyme throws
-`EnzymeMutabilityException` on the read-only `_HvpReverseClosure` /
-`_BatchHvpReverseClosure`, which capture `gradlogp`.
-
-It deliberately does not choose a differentiation mode. Which direction a pass
-runs is the user's call when they state one and DI's to resolve from the operator
-when they don't; this package is not an AD package and has no business overriding
-either. Picking one here also used to corrupt a `SecondOrder`, whose halves carry
-directions of their own (see `_normalized_second_order`).
-
-Callers hand this a single pass, never a `SecondOrder`: the strategy paths below
-run one AD pass over a hand-written `gradlogp`, and `_resolve_hvp` sends every
-`SecondOrder` to `_make_hvp_fn_second_order` before they are reached.
-`_normalized_second_order` is the one caller that starts from a pair, and it
-selects the outer half itself.
-=#
+# Extensions may add annotations required by DEER's wrappers, but must not
+# choose a differentiation mode.
 _normalized_backend(backend::AbstractADType) = backend
 
 function _prepare_hvp_via_grad_reverse(
@@ -300,25 +281,34 @@ function _make_hvp_batch_fn(
     return (X, V) -> _batch_hvp_via_grad_reverse_prepared(prep, X, V)
 end
 
-#=
----------------------------------------------------------------------------
-Second-order HVP, for a model whose gradient is itself AD-derived. `DI.hvp`
-takes both passes over the log-density, so these never touch the gradient slot.
-Preferred over pushing tangents through a prepared DI gradient, which drops out
-of its preparation once the outer pass hands it an unexpected tangent type.
+#= Fallbacks that ReactantExt overrides with `backend::AutoReactant` methods.
+They must stay strictly wider than the extension's signatures: do not type as `AutoReactant` =#
+function _make_hvp_fn(
+    ::ReactantHVP, gradlogp, backend::AbstractADType, x_template::AbstractVector
+)
+    return error(_REACTANT_LOAD_HINT)
+end
 
-Both halves are passed to `DI.hvp` as the user composed them, so the direction
-each one runs in is theirs and DI's, not ours. Normalization touches only the
-outer half, and only to fill in annotations for the wrappers being
-differentiated; because it never substitutes a mode, `DI.hvp_mode` of the pair is
-the same before and after. The inner half is a plain first-order gradient over
-the user's own `logdensity` and is passed straight through.
+function _make_hvp_batch_fn(
+    ::ReactantHVP, grad_batch, backend::AbstractADType, X_template::AbstractMatrix
+)
+    return error(_REACTANT_LOAD_HINT)
+end
 
-The batched form differentiates `sum(logdensity_batch(X))`, whose Hessian is
-block-diagonal by column independence, so its HVP along `V` is the columnwise
-HVP. Same argument the batched gradient rests on.
----------------------------------------------------------------------------
-=#
+function _make_hvp_fn_second_order(
+    logdensity, backend::AbstractADType, x_template::AbstractVector
+)
+    return error(_REACTANT_LOAD_HINT)
+end
+
+function _make_hvp_batch_fn_second_order(
+    logdensity_batch_sum, backend::AbstractADType, X_template::AbstractMatrix
+)
+    return error(_REACTANT_LOAD_HINT)
+end
+
+# DI.hvp differentiates the log-density twice; it does not differentiate the
+# prepared gradient. Only the outer backend receives DEER-specific annotations.
 function _normalized_second_order(backend::DI.SecondOrder)
     return DI.SecondOrder(_normalized_backend(DI.outer(backend)), DI.inner(backend))
 end

--- a/src/DEER/DEERScan.jl
+++ b/src/DEER/DEERScan.jl
@@ -12,8 +12,8 @@ export AffineScanWorkspace,
 Reusable workspace for the diagonal affine scan.
 
 Buffers are allocated with the same array type / device placement as the template
-matrix used to construct the workspace, so this is GPU-compatible for `CuArray`
-inputs and CPU-compatible for standard arrays.
+matrix used to construct the workspace, so this works on GPU arrays and CPU
+arrays alike.
 """
 struct AffineScanWorkspace{M}
     alpha::M
@@ -88,7 +88,7 @@ using the composition rule
     (a2, b2) ∘ (a1, b1) = (a2 .* a1, a2 .* b1 .+ b2)
 
 The implementation is generic over `AbstractMatrix` and is intended to work on
-CPU arrays and GPU arrays (`CuArray`) as long as broadcasted assignment and
+CPU arrays and GPU arrays alike, as long as broadcasted assignment and
 slicing/views are supported by the array type.
 
 Notes:

--- a/src/ParallelMCMC.jl
+++ b/src/ParallelMCMC.jl
@@ -2,7 +2,6 @@ module ParallelMCMC
 
 using AbstractMCMC
 using ADTypes: AbstractADType
-using CUDA
 using DifferentiationInterface: DifferentiationInterface
 using FlexiChains
 using LinearAlgebra
@@ -27,6 +26,25 @@ that aborts Enzyme; owning both keeps each opaque to Enzyme's reverse rewriter.
 pmcmc_matmul(A::AbstractVecOrMat, B::AbstractVecOrMat) = A * B
 pmcmc_dot(a::AbstractVector, b::AbstractVector) = dot(a, b)
 pmcmc_dotsum(A::AbstractVecOrMat, B::AbstractVecOrMat) = sum(A .* B)
+
+"""
+    needs_host_staging(x::AbstractArray) -> Bool
+
+Whether `x` has to be filled on the host and copied over, rather than written
+element by element in place. `false` for anything with cheap scalar indexing,
+which is the default.
+
+The random fills — MALA's normal noise, DEER's Rademacher probes — are the only
+places this matters: writing them one element at a time into device memory is
+either an outright error or one kernel launch per element. Array types that
+cannot take those writes say so here, and the fills stage through a host buffer
+that the workspace keeps around.
+
+Loading CUDA.jl opts `CuArray` in via `ext/CUDAExt.jl`; another device array
+type is one method away.
+"""
+needs_host_staging(::AbstractArray) = false
+
 
 include("MALA/MALA.jl")
 include("DEER/DEERScan.jl")

--- a/src/ParallelMCMC.jl
+++ b/src/ParallelMCMC.jl
@@ -1,7 +1,7 @@
 module ParallelMCMC
 
 using AbstractMCMC
-using ADTypes: AbstractADType
+using ADTypes: ADTypes, AbstractADType
 using CUDA
 using DifferentiationInterface: DifferentiationInterface
 using FlexiChains
@@ -18,15 +18,29 @@ stable function identities for backend-specific AD rules in `ext/EnzymeExt.jl`
 without committing type piracy on `Base.*` / `Base.dot` / `Base.sum`. User
 model code that wants those rules to fire (notably on GPU) should call these
 instead. See `ext/EnzymeExt.jl` for the gc-transition abort they work around.
-
-Why both a matmul and reductions: the GPU AD-HVP reverse path runs Enzyme
-through `gradlogp` *and* through a scalar reduction wrapping it (see DEER's
-`_HvpReverseClosure`). The reduction is what emits the `cuMemcpyDtoHAsync_v2`
-that aborts Enzyme; owning both keeps each opaque to Enzyme's reverse rewriter.
 =#
 pmcmc_matmul(A::AbstractVecOrMat, B::AbstractVecOrMat) = A * B
 pmcmc_dot(a::AbstractVector, b::AbstractVector) = dot(a, b)
 pmcmc_dotsum(A::AbstractVecOrMat, B::AbstractVecOrMat) = sum(A .* B)
+
+"""
+    needs_host_staging(x::AbstractArray) -> Bool
+
+Whether `x` has to be filled on the host and copied over, rather than written
+element by element in place. `false` for anything with cheap scalar indexing,
+which is the default.
+
+`ReactantExt` also reads it as "this array lives on a device", to warn when the
+XLA client is on the host while the parameters are not.
+"""
+needs_host_staging(::AbstractArray) = false
+
+# TODO: Move this to a CUDA extension see #68
+needs_host_staging(::CUDA.CuArray) = true
+
+#= Lives here rather than in `DEER` because both DEER's `ReactantHVP` fallbacks
+and `interface.jl`'s gradient hooks report it. =#
+const _REACTANT_LOAD_HINT = "AutoReactant requires Reactant.jl: add `using Reactant` to load ParallelMCMC's ReactantExt."
 
 include("MALA/MALA.jl")
 include("DEER/DEERScan.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -8,53 +8,38 @@ Defines model/sampler/state/transition types and implements
 """
     DensityModel(logdensity, grad_logdensity, dim; param_names, logdensity_batch, grad_logdensity_batch, hvp, hvp_batch)
 
-Wraps a log-density function, its gradient, and optional Hessian-vector
-product helpers for use with ParallelMCMC samplers.
+Wrap a log-density and its derivatives for ParallelMCMC samplers.
 
-The derivative slots (`grad_logdensity`, `hvp`, `grad_logdensity_batch`,
-`hvp_batch`) take either a callable or an `ADTypes.AbstractADType`. Backends
-are turned into prepared DifferentiationInterface callables when sampling
-starts, and any AD failure surfaces there. So a model needs nothing beyond
-the log-density:
+Each derivative slot (`grad_logdensity`, `hvp`, `grad_logdensity_batch`,
+`hvp_batch`) takes a callable or an `ADTypes.AbstractADType`, so a model can be
+built from the log-density alone:
 
     DensityModel(logp, AutoForwardDiff(), dim)
 
-How a backend in `hvp` / `hvp_batch` gets its second derivative depends on the
-gradient slot. Over a hand-written gradient it is a single AD pass across your
-own code. Over an AD-derived one it is
-`DifferentiationInterface.SecondOrder(hvp_backend, grad_backend)`, taken through
-DI's second-order operator. Passing a `SecondOrder` yourself always means the
-latter, and bypasses the gradient slot even when you wrote it by hand.
+Backends are prepared when sampling starts. An HVP backend differentiates a
+callable gradient once. With an AD-derived gradient it forms
+`DifferentiationInterface.SecondOrder(hvp_backend, grad_backend)` on the
+log-density. An explicit `SecondOrder` also bypasses the gradient slot.
 
 - `logdensity(x::AbstractVector) -> Real`
-- `grad_logdensity` — callable `x -> AbstractVector`, or a backend to
-  differentiate `logdensity` with.
+- `grad_logdensity` — callable `x -> AbstractVector`, or an AD backend.
 - `hvp` — optional callable `(x, v) -> AbstractVector`, or a backend. If
   `nothing`, DEER builds the HVP from the sampler's `backend`.
 - `logdensity_batch(X::AbstractMatrix) -> AbstractVector` — optional batched
-  log-density over columns (callable only). Columns must be independent:
-  element `t` of the result may depend on column `t` of `X` and nothing else.
-  A batched gradient derived from this is one gradient of its sum, so coupling
-  between columns would go unnoticed and give wrong derivatives.
+  log-density over independent columns.
 - `grad_logdensity_batch` — optional callable `X -> AbstractMatrix`, or a
-  backend to differentiate `logdensity_batch` with. Left out alongside a
-  `logdensity_batch`, it is derived when `grad_logdensity` is a backend.
+  backend. It is derived from `logdensity_batch` when `grad_logdensity` is a
+  backend.
 - `hvp_batch` — optional callable `(X, V) -> AbstractMatrix`, or a backend,
-  resolved against `grad_logdensity_batch` the same way `hvp` is against
-  `grad_logdensity`.
+  resolved like `hvp`.
 - `dim::Int` — dimensionality of the parameter space
 - `param_names` — optional collection of parameter names used in `FlexiChains` output. If
   `nothing` (the default), uses a single vector-valued parameter `:x` with shape `(dim,)`.
   See the [`Parameter names`](@ref parameter-names) section of the docs for more
   information.
 
-Both batched derivative slots require `logdensity_batch`, which the batched
-update evaluates directly. `logdensity_batch` alone is allowed and scores whole
-trajectories at once without switching the batched update on.
-
-`ParallelMALASampler` runs the batched DEER update once it has a
-`logdensity_batch` and a batched gradient: either `grad_logdensity_batch`, or one
-derived from `logdensity_batch` when `grad_logdensity` is a backend.
+Both batched derivative slots require `logdensity_batch`. `AutoReactant()` has
+additional pairing and tracing constraints; see the GPU guide.
 """
 struct DensityModel{F,G,H,FB,GB,HB,PN} <: AbstractMCMC.AbstractModel
     logdensity::F
@@ -67,9 +52,6 @@ struct DensityModel{F,G,H,FB,GB,HB,PN} <: AbstractMCMC.AbstractModel
     param_names::PN
 end
 
-"""
-Primary constructor — accepts optional batched functions as keyword arguments.
-"""
 function DensityModel(
     logdensity,
     grad_logdensity,
@@ -80,32 +62,16 @@ function DensityModel(
     grad_logdensity_batch=nothing,
     hvp_batch=nothing,
 )
-    logdensity isa AbstractADType && throw(
-        ArgumentError(
-            "logdensity must be a callable, not an AD backend; there is nothing to derive it from",
-        ),
-    )
-    logdensity_batch isa AbstractADType && throw(
-        ArgumentError(
-            "logdensity_batch must be a callable, not an AD backend; there is nothing to derive it from",
-        ),
-    )
+    logdensity isa AbstractADType &&
+        throw(ArgumentError("logdensity must be callable, not an AD backend"))
+    logdensity_batch isa AbstractADType &&
+        throw(ArgumentError("logdensity_batch must be callable, not an AD backend"))
     grad_logdensity === nothing && throw(
         ArgumentError(
             "grad_logdensity must be a callable or an ADTypes.AbstractADType backend"
         ),
     )
-    #= The batched DEER update evaluates `logdensity_batch` itself, so neither
-    batched derivative is usable without one: a backend would have nothing to
-    differentiate, and a callable would never be reached. Rejected here rather
-    than silently ignored. A `logdensity_batch` on its own is allowed, and
-    `_prepare_model` decides from the gradient slot whether the path can run. =#
-    _batch_needs_logp(name) = throw(
-        ArgumentError(
-            "$name requires logdensity_batch: the batched DEER path evaluates the " *
-            "batched log-density, so it cannot run without one",
-        ),
-    )
+    _batch_needs_logp(name) = throw(ArgumentError("$name requires logdensity_batch"))
     if logdensity_batch === nothing
         grad_logdensity_batch === nothing || _batch_needs_logp("grad_logdensity_batch")
         hvp_batch === nothing || _batch_needs_logp("hvp_batch")
@@ -123,17 +89,8 @@ function DensityModel(
 end
 
 """
-A [`DensityModel`](@ref) with its backend slots resolved to prepared
-DifferentiationInterface callables. `_prepare_model` builds these, and the
-sampler internals take them rather than a `DensityModel`, so no slot of one
-of these ever holds an `AbstractADType`. Which slots are filled depends on
-the sampler: the sequential samplers only need `grad_logdensity` and get
-`nothing` for the DEER-only slots, DEER fills the rest.
-
-`source` is the `DensityModel` this was prepared from. A sampler state carries
-a prepped model so the preparation is reused across steps, and `initial_state`
-can hand such a state to a `step` called on a different model; `source` is how
-that `step` tells the two apart (see `_prepped_for`).
+A [`DensityModel`](@ref) whose AD backends have been resolved to callables.
+`source` prevents a cached preparation from being reused with another model.
 """
 struct PreppedDensityModel{F,G,H,FB,GB,HB,PN,SM<:DensityModel}
     logdensity::F
@@ -147,20 +104,10 @@ struct PreppedDensityModel{F,G,H,FB,GB,HB,PN,SM<:DensityModel}
     source::SM
 end
 
-#=
-Whether a prepped model carried in a state was built from the model a `step`
-was handed. Identity, not equality: an equal-but-distinct `DensityModel` just
-costs one re-preparation, whereas treating a different model as a match would
-silently sample the wrong target.
-=#
+# Identity is required: reusing another model's preparation would sample the wrong target.
 _prepped_for(prepped::PreppedDensityModel, model::DensityModel) = prepped.source === model
 
-#=
-Resolved gradient wrappers. Structs rather than anonymous closures since DI keys
-preparations on function identity. `TX` is the input type the prep was made for;
-anything else falls back to unprepared `DI.gradient` rather than failing. In a
-normal run the prepared branch is the one that fires.
-=#
+# DI keys preparations on function identity. Other input types use an unprepared call.
 struct _ADGradient{F,B<:AbstractADType,P,TX}
     logdensity::F
     backend::B
@@ -211,22 +158,31 @@ function _resolve_gradient_batch(
     )
 end
 
-#=
-Resolve an HVP slot given as a backend. `grad_backend` is the backend that
-produced `grad`, or nothing when the gradient slot held a callable. Dispatch is
-on types alone, so the branch folds and the returned closure type stays
-statically known.
+function _resolve_gradient(
+    logdensity, backend::ADTypes.AutoReactant, x_template::AbstractVector
+)
+    return _reactant_resolve_gradient(logdensity, backend, x_template)
+end
+function _reactant_resolve_gradient(logdensity, backend, x_template)
+    return error(_REACTANT_LOAD_HINT)
+end
 
-A `SecondOrder` bypasses the gradient slot even when that slot is hand-written:
-naming both passes asks for two derivatives of `logdensity`. The slot is still
-the drift term the MALA step uses.
-=#
+function _resolve_gradient_batch(
+    logdensity_batch, backend::ADTypes.AutoReactant, X_template::AbstractMatrix
+)
+    return _reactant_resolve_gradient_batch(logdensity_batch, backend, X_template)
+end
+function _reactant_resolve_gradient_batch(logdensity_batch, backend, X_template)
+    return error(_REACTANT_LOAD_HINT)
+end
+
+# An explicit SecondOrder differentiates logdensity and bypasses the gradient slot.
 function _resolve_hvp(logdensity, grad, grad_backend, hvp_backend, x_template)
     if hvp_backend isa DI.SecondOrder
         return DEER._make_hvp_fn_second_order(logdensity, hvp_backend, x_template)
     elseif grad_backend !== nothing
         return DEER._make_hvp_fn_second_order(
-            logdensity, DI.SecondOrder(hvp_backend, grad_backend), x_template
+            logdensity, _second_order(hvp_backend, grad_backend), x_template
         )
     else
         return DEER._make_hvp_fn(
@@ -235,7 +191,6 @@ function _resolve_hvp(logdensity, grad, grad_backend, hvp_backend, x_template)
     end
 end
 
-# Batched counterpart, on `sum(logdensity_batch(X))` for the second-order paths.
 function _resolve_hvp_batch(
     logdensity_batch, grad_batch, grad_batch_backend, hvp_backend, X_template
 )
@@ -246,7 +201,7 @@ function _resolve_hvp_batch(
     elseif grad_batch_backend !== nothing
         return DEER._make_hvp_batch_fn_second_order(
             _BatchLogdensitySum(logdensity_batch),
-            DI.SecondOrder(hvp_backend, grad_batch_backend),
+            _second_order(hvp_backend, grad_batch_backend),
             X_template,
         )
     else
@@ -256,24 +211,66 @@ function _resolve_hvp_batch(
     end
 end
 
+# Reactant implements the two passes itself; DI composes all other backends.
+_second_order(hvp_backend, grad_backend) = DI.SecondOrder(hvp_backend, grad_backend)
+function _second_order(hvp_backend::ADTypes.AutoReactant, ::ADTypes.AutoReactant)
+    return hvp_backend
+end
+
+_check_reactant_pair(grad_backend, hvp_backend) = nothing
+_check_reactant_pair(::ADTypes.AutoReactant, ::ADTypes.AutoReactant) = nothing
+_check_reactant_pair(::Nothing, ::ADTypes.AutoReactant) = nothing
+
+function _check_reactant_pair(grad_backend::ADTypes.AutoReactant, hvp_backend)
+    return throw(
+        ArgumentError(
+            "an AutoReactant gradient requires an AutoReactant HVP backend; " *
+            "got $(hvp_backend)",
+        ),
+    )
+end
+
+function _check_reactant_pair(grad_backend, hvp_backend::ADTypes.AutoReactant)
+    return throw(
+        ArgumentError(
+            "an AutoReactant HVP requires an AutoReactant or callable gradient; " *
+            "got backend $(grad_backend)",
+        ),
+    )
+end
+
+function _check_reactant_pair(::ADTypes.AutoReactant, hvp_backend::DI.SecondOrder)
+    return throw(
+        ArgumentError(
+            "an AutoReactant gradient requires a bare AutoReactant HVP backend; " *
+            "got $(hvp_backend)",
+        ),
+    )
+end
+
+function _check_reactant_pair(grad_backend, hvp_backend::DI.SecondOrder)
+    _second_order_has_reactant(hvp_backend) || return nothing
+    return throw(
+        ArgumentError(
+            "AutoReactant cannot be used inside DifferentiationInterface.SecondOrder; " *
+            "use a bare AutoReactant() HVP backend",
+        ),
+    )
+end
+
+function _second_order_has_reactant(so::DI.SecondOrder)
+    return DI.outer(so) isa ADTypes.AutoReactant || DI.inner(so) isa ADTypes.AutoReactant
+end
+
+_check_reactant_hvp_source(grad, hvp_backend) = nothing
+
 """
     _prepare_model(model, x_template)                    -> PreppedDensityModel
     _prepare_model(model, x_template, T::Int, backend)   -> PreppedDensityModel
 
-Resolve the backend slots of `model` into prepared DI callables, preparing
-at `x_template`. The two-argument form only does `grad_logdensity`, which is
-all the sequential samplers use, and leaves the DEER-only slots `nothing`.
-
-The four-argument form also does the HVP and batched slots, preparing those at
-a `(dim, T)` template. A missing `hvp` comes from the sampler's `backend`, and
-a missing `hvp_batch` from the model's own `hvp` backend if it has one and the
-sampler's otherwise. A missing `grad_logdensity_batch` is derived only when
-`grad_logdensity` is a backend, never from the sampler's `backend`, which would
-let it decide whether the batched update runs.
-
-The batched slots are filled only when `logdensity_batch` is present and a
-batched gradient is reachable; otherwise the batched path stays off and the
-unbatched update covers it.
+Resolve AD backends into prepared callables at `x_template`. The two-argument
+form prepares only the gradient. The four-argument form also prepares DEER's
+HVP and batched slots at shape `(model.dim, T)`.
 """
 function _prepare_model(model::DensityModel, x_template::AbstractVector)
     grad = if model.grad_logdensity isa AbstractADType
@@ -281,10 +278,6 @@ function _prepare_model(model::DensityModel, x_template::AbstractVector)
     else
         model.grad_logdensity
     end
-    #= The derivative slots DEER alone reads are dropped rather than passed
-    along: a sequential sampler never looks at them, and carrying an
-    unresolved backend would break the invariant that no slot here holds an
-    `AbstractADType`. =#
     return PreppedDensityModel(
         model.logdensity,
         grad,
@@ -301,31 +294,37 @@ end
 function _prepare_model(model::DensityModel, x_template::AbstractVector, T::Int, backend)
     grad_backend =
         model.grad_logdensity isa AbstractADType ? model.grad_logdensity : nothing
-    grad = if grad_backend !== nothing
-        _resolve_gradient(model.logdensity, grad_backend, x_template)
-    else
-        model.grad_logdensity
-    end
 
-    hvp = if model.hvp === nothing || model.hvp isa AbstractADType
-        hvp_backend = model.hvp === nothing ? backend : model.hvp
-        hvp_backend === nothing && throw(
+    # Validate the pair before an AutoReactant gradient triggers compilation.
+    needs_hvp = model.hvp === nothing || model.hvp isa AbstractADType
+    hvp_backend = if needs_hvp
+        hb = model.hvp === nothing ? backend : model.hvp
+        hb === nothing && throw(
             ArgumentError(
                 "ParallelMALASampler needs a Hessian-vector product: supply `hvp` " *
                 "on the DensityModel (callable or AD backend), or pass `backend=` " *
                 "to ParallelMALASampler",
             ),
         )
+        _check_reactant_pair(grad_backend, hb)
+        _check_reactant_hvp_source(model.grad_logdensity, hb)
+        hb
+    else
+        nothing
+    end
+
+    grad = if grad_backend !== nothing
+        _resolve_gradient(model.logdensity, grad_backend, x_template)
+    else
+        model.grad_logdensity
+    end
+
+    hvp = if needs_hvp
         _resolve_hvp(model.logdensity, grad, grad_backend, hvp_backend, x_template)
     else
         model.hvp
     end
 
-    #= A batched log-density with no batched gradient gets one from the model's
-    own gradient backend, never the sampler's: a model with a hand-written
-    gradient has not opted into AD, and deriving one anyway would let `backend=`
-    decide which update path runs. Failing to derive leaves the path off rather
-    than raising, since `_trajectory_logps` uses `logdensity_batch` regardless. =#
     grad_batch = model.grad_logdensity_batch
     if grad_batch === nothing && model.logdensity_batch !== nothing
         grad_batch = grad_backend
@@ -340,26 +339,29 @@ function _prepare_model(model::DensityModel, x_template::AbstractVector, T::Int,
         X_template = similar(x_template, length(x_template), T)
         X_template .= x_template
 
+        needs_hvp_batch = hvp_batch === nothing || hvp_batch isa AbstractADType
+        hvp_batch_backend = if needs_hvp_batch
+            hbb = if hvp_batch === nothing
+                model.hvp isa AbstractADType ? model.hvp : backend
+            else
+                hvp_batch
+            end
+            hbb === nothing && throw(
+                ArgumentError("batched DEER requires `hvp_batch` or a sampler `backend`"),
+            )
+            _check_reactant_pair(grad_batch_backend, hbb)
+            hbb
+        else
+            nothing
+        end
+
         if grad_batch_backend !== nothing
             grad_batch = _resolve_gradient_batch(
                 model.logdensity_batch, grad_batch_backend, X_template
             )
         end
 
-        if hvp_batch === nothing || hvp_batch isa AbstractADType
-            # The model's own HVP backend if it has one, else the sampler's.
-            hvp_batch_backend = if hvp_batch === nothing
-                model.hvp isa AbstractADType ? model.hvp : backend
-            else
-                hvp_batch
-            end
-            hvp_batch_backend === nothing && throw(
-                ArgumentError(
-                    "the batched DEER path needs a batched Hessian-vector product: " *
-                    "supply `hvp_batch` on the DensityModel (callable or AD backend), " *
-                    "or pass `backend=` to ParallelMALASampler",
-                ),
-            )
+        if needs_hvp_batch
             hvp_batch = _resolve_hvp_batch(
                 model.logdensity_batch,
                 grad_batch,
@@ -369,14 +371,10 @@ function _prepare_model(model::DensityModel, x_template::AbstractVector, T::Int,
             )
         end
     elseif hvp_batch !== nothing
-        #= Raise rather than drop it: `hvp_batch` was supplied explicitly, and
-        the alternative is silently running the unbatched update. =#
+        # Do not silently ignore an explicitly supplied HVP.
         throw(
             ArgumentError(
-                "hvp_batch has no batched gradient to go with it: supply " *
-                "`grad_logdensity_batch` on the DensityModel (a callable, or a backend " *
-                "to derive one from `logdensity_batch`). A backend in `grad_logdensity` " *
-                "also derives one; `backend=` on ParallelMALASampler does not.",
+                "hvp_batch has no batched gradient; supply grad_logdensity_batch or an AD-backed grad_logdensity",
             ),
         )
     end
@@ -403,6 +401,17 @@ struct LogDensityProblemPrimal{L}
 end
 struct LogDensityProblemGradient{L}
     ld::L
+end
+
+function _check_reactant_hvp_source(
+    ::LogDensityProblemGradient, hvp_backend::ADTypes.AutoReactant
+)
+    return throw(
+        ArgumentError(
+            "AutoReactant cannot differentiate a LogDensityProblems-derived gradient; " *
+            "supply a Reactant-traceable gradient callable instead",
+        ),
+    )
 end
 
 """
@@ -581,11 +590,12 @@ DEER-parallelized MALA sampler.
 Supported Jacobian modes are `:stoch_diag` (the default Hutchinson diagonal
 estimator) and `:diag` (exact diagonal via `D` JVPs).
 
-`backend` is the fallback source of Hessian-vector products, used when the
-`DensityModel` brings no `hvp` / `hvp_batch` of its own. That is all it does: it
-never supplies a gradient, so it cannot change which update path runs or put AD
-on a function the model did not already have a backend for. A model carrying its
-own HVPs does not need it.
+`backend` supplies Hessian-vector products when the `DensityModel` brings no
+`hvp` / `hvp_batch` of its own. It does not supply gradients. Leave it out when
+the model carries its own HVPs.
+
+With `backend=ADTypes.AutoReactant()`, `grad_logdensity` must be `AutoReactant()`
+or a callable.
 """
 struct ParallelMALASampler{FP<:AbstractFloat,CM,AD} <: AbstractMCMC.AbstractSampler
     epsilon::FP
@@ -715,7 +725,6 @@ function _build_mala_deer_rec(
     logp = model.logdensity
     gradlogp = model.grad_logdensity
 
-    # `hvp` / `hvp_batch` were resolved to callables in `_prepare_model`.
     hvp_fn = model.hvp
 
     # Exact forward step.
@@ -934,9 +943,9 @@ function _construct_flexichain(
     param_names::Any,
     model::DensityModel,
 ) where {TKey}
-    #= Wrap user-supplied names in `Parameter`. This allows people to specify, e.g.,
-    `param_names=(:x, :y, :z=>(2,))` without faffing with `Parameter` themselves. Also
-    'upgrade' symbol parameter names to VarNames if the user requested a VNChain. =#
+    # Wrap user-supplied names in `Parameter`. This allows people to specify, e.g.,
+    # `param_names=(:x, :y, :z=>(2,))` without faffing with `Parameter` themselves. Also
+    # 'upgrade' symbol parameter names to VarNames if the user requested a VNChain.
     to_parameter(vn::VarName) = FlexiChains.Parameter(vn)
     to_parameter(s::Symbol) = FlexiChains.Parameter(TKey <: VarName ? VarName{s}() : s)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -450,15 +450,16 @@ end
 
 function _make_noise_buffer(x::AbstractVector, ::Type{FP}, D::Int) where {FP}
     ξ = similar(x, FP, D)
-    host = ξ isa CUDA.CuArray ? Vector{FP}(undef, D) : nothing
+    host = needs_host_staging(ξ) ? Vector{FP}(undef, D) : nothing
     return ξ, host
 end
 
 function _randn_like!(
     rng::Random.AbstractRNG, ξ::AbstractVector{FP}, host::Union{Nothing,AbstractVector{FP}}
 ) where {FP}
-    if ξ isa CUDA.CuArray
-        host === nothing && error("CuArray normal noise requires a reusable host buffer")
+    if needs_host_staging(ξ)
+        host === nothing &&
+            error("normal noise for $(typeof(ξ)) requires a reusable host buffer")
         randn!(rng, host)
         copyto!(ξ, host)
     else
@@ -683,7 +684,7 @@ function _make_mala_tape_block(
     Xi = similar(x0, FP, D, T)
     U_host = Vector{FP}(undef, T)
 
-    if Xi isa CUDA.CuArray
+    if needs_host_staging(Xi)
         Xi_host = Matrix{FP}(undef, D, T)
         for t in 1:T
             randn!(rng, view(Xi_host, :, t))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -22,8 +22,9 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
-[extras]
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
-
 [compat]
 JuliaFormatter = "2.12"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 using ParallelMCMC
 using Test
 
+#= Reactant tests are opt-in because Reactant_jll is a large download. Opting in
+also requires Reactant in the test environment: it is only an [extra] in
+test/Project.toml, which Pkg.test does not install. The Reactant-free checks of
+the AutoReactant validation logic run unconditionally
+(test-Reactant-Validation.jl). =#
+const _RUN_REACTANT_TESTS =
+    lowercase(get(ENV, "PARALLELMCMC_TEST_REACTANT", "false")) in ("1", "true", "yes")
+
 @testset verbose=true "ParallelMCMC" begin
     #=
     Don't add your tests to runtests.jl. Instead, create files named
@@ -12,6 +20,10 @@ using Test
     for (root, dirs, files) in walkdir(@__DIR__)
         for file in files
             if isnothing(match(r"^test-.*\.jl$", file))
+                continue
+            end
+            if file == "test-Reactant-HVP.jl" && !_RUN_REACTANT_TESTS
+                @info "Skipping $file (set PARALLELMCMC_TEST_REACTANT=true to opt in)"
                 continue
             end
             title = titlecase(replace(splitext(file[6:end])[1], "-" => " "))

--- a/test/test-ADType-Slots.jl
+++ b/test/test-ADType-Slots.jl
@@ -8,10 +8,6 @@ using ADTypes
 using Enzyme: Enzyme
 using ForwardDiff: ForwardDiff
 
-#=
-Backend-or-callable slots on `DensityModel` (#52, #40). A standard Gaussian
-target so every resolved slot has a closed form: ∇logp = -x, hvp(x, v) = -v.
-=#
 logp_slots(x) = -0.5 * dot(x, x)
 gradlogp_slots(x) = -x
 logp_batch_slots(X) = vec(-0.5 .* sum(abs2, X; dims=1))
@@ -22,13 +18,10 @@ const CT_SLOTS = FlexiChains.FlexiChain{Symbol}
 const DI_SLOTS = ParallelMCMC.DI
 
 @testset "constructor validation" begin
-    # primal slots cannot be backends: nothing to derive them from
     @test_throws ArgumentError DensityModel(AutoForwardDiff(), gradlogp_slots, D_SLOTS)
     @test_throws ArgumentError DensityModel(
         logp_slots, gradlogp_slots, D_SLOTS; logdensity_batch=AutoForwardDiff()
     )
-    #= Batched derivative slots need a logdensity_batch, callables included: the
-    batched update evaluates it, so without one the slot could never be reached. =#
     for slot in (AutoForwardDiff(), gradlogp_batch_slots)
         @test_throws ArgumentError DensityModel(
             logp_slots, gradlogp_slots, D_SLOTS; grad_logdensity_batch=slot
@@ -39,11 +32,9 @@ const DI_SLOTS = ParallelMCMC.DI
             logp_slots, gradlogp_slots, D_SLOTS; hvp_batch=slot
         )
     end
-    # a logdensity_batch on its own is allowed: it scores whole trajectories
     @test DensityModel(
         logp_slots, gradlogp_slots, D_SLOTS; logdensity_batch=logp_batch_slots
     ) isa DensityModel
-    # grad slot is mandatory (callable or backend)
     @test_throws ArgumentError DensityModel(logp_slots, nothing, D_SLOTS)
 
     @test DensityModel(
@@ -65,7 +56,6 @@ end
         @test m_r isa ParallelMCMC.PreppedDensityModel
         @test m_r.grad_logdensity === gradlogp_slots
 
-        # DEER form: a user-supplied hvp callable passes through untouched
         hvp_fn = (x, v) -> -v
         model_hvp = DensityModel(logp_slots, gradlogp_slots, D_SLOTS; hvp=hvp_fn)
         m_deer = ParallelMCMC._prepare_model(model_hvp, x0, 8, nothing)
@@ -103,7 +93,6 @@ end
         m_r = ParallelMCMC._prepare_model(model, x0, 8, AutoForwardDiff())
         @test m_r.hvp(x0, v) ≈ -v
 
-        # no hvp source anywhere
         @test_throws ArgumentError ParallelMCMC._prepare_model(model, x0, 8, nothing)
     end
 
@@ -124,7 +113,6 @@ end
         @test m_r.grad_logdensity_batch(X) ≈ -X
         @test m_r.hvp_batch(X, V) ≈ -V
 
-        # hvp_batch fallback from the sampler backend
         model_fb = DensityModel(
             logp_slots,
             gradlogp_slots,
@@ -149,7 +137,6 @@ end
         )
         m_r = ParallelMCMC._prepare_model(model, x0)
         @test m_r isa ParallelMCMC.PreppedDensityModel
-        # no slot of a prepped model is left holding a backend
         @test m_r.hvp === nothing
         @test m_r.grad_logdensity_batch === nothing
         @test m_r.hvp_batch === nothing
@@ -160,7 +147,6 @@ end
         X = randn(rng, D_SLOTS, T)
         V = randn(rng, D_SLOTS, T)
 
-        # grad_logdensity_batch omitted: taken from the gradient slot's backend
         model = DensityModel(
             logp_slots,
             AutoForwardDiff(),
@@ -172,22 +158,18 @@ end
         @test m_r.grad_logdensity_batch(X) ≈ -X
         @test m_r.hvp_batch(X, V) ≈ -V
 
-        #= A hand-written gradient is not opted into AD, so the sampler backend
-        does not derive a batched gradient from `logdensity_batch` and the batched
-        path stays off. Were it otherwise, `backend=` would decide which update
-        path runs. =#
+        # A sampler backend supplies HVPs, not a missing batched gradient.
         model_an = DensityModel(
             logp_slots,
             gradlogp_slots,
             D_SLOTS;
-            hvp=(x, v) -> -v,        # so the unbatched HVP is covered either way
+            hvp=(x, v) -> -v,
             logdensity_batch=logp_batch_slots,
         )
         for spl_backend in (AutoForwardDiff(), nothing)
             m_an = ParallelMCMC._prepare_model(model_an, x0, T, spl_backend)
             @test m_an.grad_logdensity_batch === nothing
             @test m_an.hvp_batch === nothing
-            # still kept, since `_trajectory_logps` scores a whole block with it
             @test m_an.logdensity_batch === logp_batch_slots
         end
     end
@@ -197,7 +179,6 @@ end
         X = randn(rng, D_SLOTS, T)
         V = randn(rng, D_SLOTS, T)
 
-        # no grad_logdensity_batch: derived from the gradient slot's backend
         model_gs = DensityModel(
             logp_slots,
             AutoForwardDiff(),
@@ -210,9 +191,7 @@ end
         @test m_gs.grad_logdensity_batch(X) ≈ -X
         @test m_gs.hvp_batch(X, V) ≈ -V
 
-        #= Hand-written gradient, so nothing derives a batched one, and an
-        `hvp_batch` was supplied explicitly: raise instead of silently running
-        the unbatched update. The sampler backend does not rescue this. =#
+        # An explicit batched HVP is invalid when no batched gradient is reachable.
         model_nd = DensityModel(
             logp_slots,
             gradlogp_slots,
@@ -251,10 +230,8 @@ end
 end
 
 @testset "second-order HVP semantics" begin
-    #= How an `hvp` backend gets its second derivative depends on the gradient
-    slot, so the three cases are told apart with a gradient that is deliberately
-    not ∇logp: a path that differentiates the slot sees `-2x` and reports `-2v`,
-    one that differentiates `logdensity` twice reports `-v`. =#
+    # Deliberately inconsistent derivatives distinguish HVP routes: the callable
+    # gradient gives -2v, while two derivatives of logp give -v.
     off_grad(x) = -2 .* x
     rng = MersenneTwister(61)
     x0 = randn(rng, D_SLOTS)
@@ -264,10 +241,6 @@ end
     V = randn(rng, D_SLOTS, T)
 
     @testset "plain backend over a hand-written gradient is one pass over it" begin
-        #= Both `HVPStrategy` paths stay reachable end to end and keep routing on
-        `DI.hvp_mode`: a hand-written gradient is differentiated once, never
-        twice, whichever direction the backend reports. `-2v` rather than `-v` is
-        what distinguishes that from the second-order paths below. =#
         for backend in (
             AutoForwardDiff(),                      # ForwardOnGrad
             AutoEnzyme(),                           # ForwardOnGrad
@@ -280,8 +253,7 @@ end
     end
 
     @testset "an explicit SecondOrder differentiates logdensity twice" begin
-        #= Both passes are named, so the gradient slot is not the inner one even
-        when hand-written, and the inner half is honoured rather than dropped. =#
+        # Explicit SecondOrder bypasses the inconsistent callable gradient.
         model = DensityModel(
             logp_slots,
             off_grad,
@@ -291,7 +263,6 @@ end
         m_r = ParallelMCMC._prepare_model(model, x0, T, nothing)
         @test m_r.hvp(x0, v) ≈ -v
 
-        # same when it arrives as the sampler's fallback backend
         model_fb = DensityModel(logp_slots, off_grad, D_SLOTS)
         m_fb = ParallelMCMC._prepare_model(
             model_fb, x0, T, DI_SLOTS.SecondOrder(AutoForwardDiff(), AutoForwardDiff())
@@ -300,11 +271,8 @@ end
     end
 
     @testset "a backend over an AD-derived gradient composes into SecondOrder" begin
-        #= The gradient slot is a backend, so `hvp` becomes the outer half of a
-        true second-order pair rather than an AD pass over the prepared DI
-        gradient. Both readings agree numerically here (the derived gradient
-        really is ∇logp), so the check is structural: the slot has to hold the
-        closure the second-order factory builds, not the one a strategy builds. =#
+        # The type check distinguishes composition on logp from differentiation
+        # of the prepared gradient wrapper.
         second_order = ParallelMCMC.DEER._make_hvp_fn_second_order(
             logp_slots, DI_SLOTS.SecondOrder(AutoForwardDiff(), AutoForwardDiff()), x0
         )
@@ -313,11 +281,9 @@ end
         m_r = ParallelMCMC._prepare_model(model, x0, T, nothing)
         @test typeof(m_r.hvp) === typeof(second_order)
         @test m_r.hvp(x0, v) ≈ -v
-        # the resolved gradient is still the prepared AD one
         @test m_r.grad_logdensity isa ParallelMCMC._ADGradient
         @test m_r.grad_logdensity(x0) ≈ -x0
 
-        # a hand-written gradient keeps the single-pass strategy closure instead
         model_hand = DensityModel(logp_slots, off_grad, D_SLOTS; hvp=AutoForwardDiff())
         m_hand = ParallelMCMC._prepare_model(model_hand, x0, T, nothing)
         @test typeof(m_hand.hvp) !== typeof(second_order)
@@ -480,21 +446,17 @@ end
     @test s.model isa ParallelMCMC.PreppedDensityModel
     @test !(s.model.grad_logdensity isa ADTypes.AbstractADType)
     t2, s2 = ParallelMCMC.AbstractMCMC.step(rng, model, MALASampler(0.2), s)
-    # the same resolved callable is reused, not re-prepared
     @test s2.model.grad_logdensity === s.model.grad_logdensity
 
     sp = ParallelMALASampler(0.05; T=8, backend=AutoForwardDiff())
     tp, spstate = ParallelMCMC.AbstractMCMC.step(rng, model, sp)
     @test spstate.model isa ParallelMCMC.PreppedDensityModel
     @test !(spstate.model.grad_logdensity isa ADTypes.AbstractADType)
-    # sampler backend was injected: the prepped model always carries a callable hvp
     @test spstate.model.hvp !== nothing
 end
 
 @testset "a state from another model does not outrank the model passed to step" begin
-    #= The prepped model rides along in the state so preparation is reused, but
-    `initial_state` can hand a state to `step` on a different model. The model
-    argument has to win, or the wrong target gets sampled silently. =#
+    # A state may be resumed with another model; its preparation must not be reused.
     logp_tight(x) = -2.0 * dot(x, x)      # N(0, 1/2) rather than N(0, 1)
     model_a = DensityModel(logp_slots, AutoForwardDiff(), D_SLOTS)
     model_b = DensityModel(logp_tight, AutoForwardDiff(), D_SLOTS)
@@ -507,7 +469,6 @@ end
         _, s_b = ParallelMCMC.AbstractMCMC.step(MersenneTwister(72), model_b, spl, s_a)
         @test s_b.model.source === model_b
         @test s_b.model.logdensity === logp_tight
-        # re-prepared once, then reused
         _, s_b2 = ParallelMCMC.AbstractMCMC.step(MersenneTwister(73), model_b, spl, s_b)
         @test s_b2.model === s_b.model
     end
@@ -523,18 +484,15 @@ end
         spl = ParallelMALASampler(0.05; T=8, backend=AutoForwardDiff())
         _, s_a = ParallelMCMC.AbstractMCMC.step(MersenneTwister(76), model_a, spl)
         @test s_a.t == 1
-        #= What replaying model A's trajectory would have handed back. Snapshot
-        it: a re-solve writes through the same workspace. =#
+        # Snapshot before re-solving, which reuses the workspace.
         x_replayed = copy(s_a.trajectory[:, 2])
         x_resume = copy(s_a.x)
 
-        # the cached trajectory belongs to model A, so it is discarded, not replayed
         _, s_b = ParallelMCMC.AbstractMCMC.step(MersenneTwister(77), model_b, spl, s_a)
         @test s_b.model.source === model_b
         @test s_b.t == 1
         @test !(s_b.x ≈ x_replayed)
 
-        # and what it solved instead is model B's own block from that point
         _, s_fresh = ParallelMCMC.AbstractMCMC.step(
             MersenneTwister(77), model_b, spl; initial_params=x_resume
         )
@@ -545,8 +503,7 @@ end
         spl = MALASampler(0.2)
         _, s_a = ParallelMCMC.AbstractMCMC.step(MersenneTwister(78), model_a, spl)
 
-        # resuming from model A's state must match a fresh model B run from the
-        # same point: the initial step draws no noise, so the streams line up
+        # The initial step draws no noise, so both runs use the same random stream.
         c_resumed = sample(
             MersenneTwister(79),
             model_b,
@@ -571,12 +528,11 @@ end
 
 @testset "sampler backend is optional when the model specifies hvp" begin
     model = DensityModel(logp_slots, AutoForwardDiff(), D_SLOTS; hvp=AutoForwardDiff())
-    s = ParallelMALASampler(0.05; T=16)   # no backend
+    s = ParallelMALASampler(0.05; T=16)
     chain = sample(MersenneTwister(61), model, s, 64; chain_type=CT_SLOTS, progress=false)
     @test size(chain) == (64, 1)
     @test all(x -> all(isfinite, x), chain[:x])
 
-    # neither a model hvp nor a sampler backend: errors when sampling starts
     bare = DensityModel(logp_slots, gradlogp_slots, D_SLOTS)
     @test_throws ArgumentError sample(
         MersenneTwister(62), bare, s, 32; chain_type=CT_SLOTS, progress=false

--- a/test/test-CUDA-Extension.jl
+++ b/test/test-CUDA-Extension.jl
@@ -1,0 +1,96 @@
+using Test
+using Random
+using ParallelMCMC
+
+#=
+`needs_host_staging` is the only thing left tying the samplers to a particular
+GPU package (#59). These tests pin both halves of that contract: the CPU
+default, and what a device array type gets by opting in.
+=#
+
+@testset "Host staging defaults to off" begin
+    @test !ParallelMCMC.needs_host_staging(zeros(3))
+    @test !ParallelMCMC.needs_host_staging(zeros(Float32, 3, 4))
+    @test !ParallelMCMC.needs_host_staging(view(zeros(6), 1:3))
+end
+
+@testset "Workspaces skip host buffers for CPU arrays" begin
+    ws = ParallelMCMC.DEER.DEERWorkspace(randn(Float32, 5), 4)
+    @test ws.Zhost === nothing
+    @test ws.zhost === nothing
+end
+
+#=
+Stand-in for a device array: no CuArray needed, so this runs on CI without a
+GPU. It refuses `setindex!`, which is what the staged fills exist to avoid.
+=#
+struct StagedArray{T,N} <: AbstractArray{T,N}
+    data::Array{T,N}
+end
+Base.size(a::StagedArray) = size(a.data)
+Base.getindex(a::StagedArray, i::Int...) = a.data[i...]
+Base.setindex!(::StagedArray, v, i::Int...) = error("scalar indexing is unsupported")
+function Base.similar(a::StagedArray, ::Type{T}, dims::Dims) where {T}
+    return StagedArray(similar(a.data, T, dims))
+end
+Base.copyto!(a::StagedArray, src::AbstractArray) = (copyto!(a.data, src); a)
+
+ParallelMCMC.needs_host_staging(::StagedArray) = true
+
+@testset "Opting a device array type in" begin
+    x = StagedArray(zeros(Float32, 6))
+    @test ParallelMCMC.needs_host_staging(x)
+
+    #= The workspace allocates host mirrors off the same trait, so a template
+    that stages gets them and a CPU template does not. =#
+    ws = ParallelMCMC.DEER.DEERWorkspace(x, 3)
+    @test ws.Zhost isa Matrix{Float32}
+    @test size(ws.Zhost) == (6, 3)
+    @test ws.zhost isa Vector{Float32}
+    @test length(ws.zhost) == 6
+
+    #= Both the buffered and unbuffered fills have to route around setindex!;
+    the unbuffered one allocates its own staging buffer. =#
+    rng = MersenneTwister(0)
+    ParallelMCMC.DEER._rademacher!(x, rng, ws.zhost)
+    @test all(v -> abs(v) == 1.0f0, x.data)
+
+    fill!(x.data, 0.0f0)
+    ParallelMCMC.DEER._rademacher!(x, MersenneTwister(0))
+    @test all(v -> abs(v) == 1.0f0, x.data)
+
+    @test_throws DimensionMismatch ParallelMCMC.DEER._rademacher!(
+        x, rng, Vector{Float32}(undef, 2)
+    )
+end
+
+@testset "MALA noise stages through the host buffer" begin
+    ξ, host = ParallelMCMC._make_noise_buffer(StagedArray(zeros(Float32, 4)), Float32, 4)
+    @test host isa Vector{Float32}
+    ParallelMCMC._randn_like!(MersenneTwister(0), ξ, host)
+    @test ξ.data == host
+
+    # Without one there is nowhere to generate the noise, so say so rather than
+    # failing later inside setindex!.
+    @test_throws ErrorException ParallelMCMC._randn_like!(MersenneTwister(0), ξ, nothing)
+end
+
+@testset "CUDAExt loads with CUDA" begin
+    cuda_loadable = try
+        using CUDA
+        true
+    catch
+        false
+    end
+    if !cuda_loadable
+        @warn "CUDA not loadable — skipping CUDAExt test"
+    else
+        @test Base.get_extension(ParallelMCMC, :CUDAExt) !== nothing
+        # Setting the trait for `CuArray` is the whole of the extension, and it
+        # is right about the type whether or not a device is present.
+        @test hasmethod(ParallelMCMC.needs_host_staging, Tuple{CUDA.CuArray})
+        if CUDA.functional()
+            @test ParallelMCMC.needs_host_staging(CUDA.zeros(Float32, 3))
+        end
+    end
+end

--- a/test/test-HVP-Strategy.jl
+++ b/test/test-HVP-Strategy.jl
@@ -24,6 +24,11 @@ const DI_STRAT = ParallelMCMC.DEER.DI
             DEER_STRAT.ReverseOnGrad
     end
 
+    @testset "AutoReactant short-circuits hvp_mode" begin
+        @test DEER_STRAT._hvp_strategy(AutoReactant()) isa DEER_STRAT.ReactantHVP
+        @test @inferred(DEER_STRAT._hvp_strategy(AutoReactant())) isa DEER_STRAT.ReactantHVP
+    end
+
     @testset "SecondOrder follows hvp_mode's composition" begin
         so_fwd_outer = DI_STRAT.SecondOrder(AutoForwardDiff(), AutoZygote())
         @test DEER_STRAT._hvp_strategy(so_fwd_outer) isa DEER_STRAT.ForwardOnGrad
@@ -37,9 +42,6 @@ const DI_STRAT = ParallelMCMC.DEER.DI
     end
 
     @testset "normalization supplies Const but never a mode" begin
-        #= The wrappers DEER differentiates are its own types, so annotating them
-        `Const` is its business. The mode is not: one the user set is a decision,
-        and an unset one is DI's to resolve from the operator it runs. =#
         bare = DEER_STRAT._normalized_backend(AutoEnzyme())
         @test bare isa AutoEnzyme{<:Any,Enzyme.Const}
         @test bare.mode === nothing
@@ -50,21 +52,15 @@ const DI_STRAT = ParallelMCMC.DEER.DI
             @test normalized isa AutoEnzyme{<:Any,Enzyme.Const}
         end
 
-        # An annotation the user chose is left alone.
         annotated = AutoEnzyme(; function_annotation=Enzyme.Duplicated)
         @test DEER_STRAT._normalized_backend(annotated) === annotated
 
-        # Backends with no specialization pass straight through.
         @test DEER_STRAT._normalized_backend(AutoForwardDiff()) === AutoForwardDiff()
         @test DEER_STRAT._normalized_backend(AutoZygote()) === AutoZygote()
     end
 
     @testset "normalizing a SecondOrder keeps the composition DI resolved" begin
-        #= Regression for #62. Normalization used to route the outer half through
-        a forward-only hook, which pinned `Enzyme.Forward` onto it. For a pair
-        `hvp_mode` resolves to reverse -- `SecondOrder(AutoEnzyme(),
-        AutoForwardDiff())` is reverse-over-forward, its inner half being
-        forward-only -- that silently made it forward-over-forward. =#
+        # Regression #62: normalization must not change the composed HVP mode.
         for so in (
             DI_STRAT.SecondOrder(AutoEnzyme(), AutoForwardDiff()),
             DI_STRAT.SecondOrder(AutoEnzyme(), AutoZygote()),
@@ -75,14 +71,9 @@ const DI_STRAT = ParallelMCMC.DEER.DI
         )
             normalized = DEER_STRAT._normalized_second_order(so)
             @test DI_STRAT.hvp_mode(normalized) == DI_STRAT.hvp_mode(so)
-            # The inner half is the user's own first-order gradient, untouched.
             @test DI_STRAT.inner(normalized) === DI_STRAT.inner(so)
-            # And no mode is invented for the outer half either. Only `AutoEnzyme`
-            # carries a `mode`, so this is the case that could regress.
             if DI_STRAT.outer(so) isa AutoEnzyme
                 @test DI_STRAT.outer(normalized).mode === DI_STRAT.outer(so).mode
-                #= The outer half still reaches EnzymeExt's specialization rather
-                than passing through as a bare backend. =#
                 @test DI_STRAT.outer(normalized) isa AutoEnzyme{<:Any,Enzyme.Const}
             end
         end

--- a/test/test-Reactant-HVP.jl
+++ b/test/test-Reactant-HVP.jl
@@ -1,0 +1,231 @@
+using Test
+using Random
+using LinearAlgebra
+using Statistics
+using FlexiChains
+
+using ParallelMCMC
+using ADTypes
+
+# A quartic target exposes missing second-order terms that a Gaussian would hide.
+logp_r(x) = -0.25 * sum(abs2, x)^2
+gradlogp_r(x) = -sum(abs2, x) .* x
+hvp_r(x, v) = -(sum(abs2, x) .* v .+ 2 .* dot(x, v) .* x)
+logp_batch_r(X) = vec(-0.25 .* sum(abs2, X; dims=1) .^ 2)
+gradlogp_batch_r(X) = -X .* sum(abs2, X; dims=1)
+logp_r32(x) = -0.25f0 * sum(abs2, x)^2
+
+logp_gauss(x) = -0.5 * sum(abs2, x)
+gradlogp_gauss(x) = -x
+hvp_gauss(x, v) = -v
+
+const D_R = 4
+const CT_R = FlexiChains.FlexiChain{Symbol}
+
+# This file only runs when PARALLELMCMC_TEST_REACTANT opts in (see runtests.jl)
+
+using Reactant: Reactant
+using Enzyme: Enzyme
+
+@testset "Reactant HVP" begin
+    @testset "extension is loaded" begin
+        @test Base.get_extension(ParallelMCMC, :ReactantExt) !== nothing
+    end
+
+    @testset "a non-default AutoReactant mode is rejected" begin
+        bad = AutoReactant(; mode=AutoEnzyme(; mode=Enzyme.Forward))
+        model_grad = DensityModel(logp_r, bad, D_R)
+        @test_throws ArgumentError ParallelMCMC._prepare_model(
+            model_grad, zeros(D_R), 8, nothing
+        )
+
+        model_hvp = DensityModel(logp_r, gradlogp_r, D_R; hvp=bad)
+        @test_throws ArgumentError ParallelMCMC._prepare_model(
+            model_hvp, zeros(D_R), 8, nothing
+        )
+
+        @test DensityModel(logp_r, AutoReactant(), D_R) isa DensityModel
+    end
+
+    @testset "HVP matches analytic" begin
+        rng = MersenneTwister(71)
+        x = randn(rng, D_R)
+        v = randn(rng, D_R)
+
+        @testset "forward over user gradient (sampler backend)" begin
+            model = DensityModel(logp_r, gradlogp_r, D_R)
+            m_p = ParallelMCMC._prepare_model(model, x, 8, AutoReactant())
+            @test m_p.hvp(x, v) ≈ hvp_r(x, v)
+        end
+
+        @testset "forward-over-reverse from logp alone (both slots AutoReactant)" begin
+            model = DensityModel(logp_r, AutoReactant(), D_R; hvp=AutoReactant())
+            m_p = ParallelMCMC._prepare_model(model, x, 8, nothing)
+            @test m_p.grad_logdensity(x) ≈ gradlogp_r(x)
+            @test m_p.hvp(x, v) ≈ hvp_r(x, v)
+        end
+
+        @testset "batched slots" begin
+            T = 8
+            X = randn(rng, D_R, T)
+            V = randn(rng, D_R, T)
+            Hv_cols = reduce(hcat, [hvp_r(X[:, t], V[:, t]) for t in 1:T])
+
+            model = DensityModel(
+                logp_r,
+                AutoReactant(),
+                D_R;
+                logdensity_batch=logp_batch_r,
+                grad_logdensity_batch=AutoReactant(),
+                hvp=AutoReactant(),
+                hvp_batch=AutoReactant(),
+            )
+            m_p = ParallelMCMC._prepare_model(model, X[:, 1], T, nothing)
+            @test m_p.grad_logdensity_batch(X) ≈ gradlogp_batch_r(X)
+            @test m_p.hvp_batch(X, V) ≈ Hv_cols
+        end
+
+        @testset "forward over user batched gradient (hvp_batch=AutoReactant())" begin
+            T = 8
+            X = randn(rng, D_R, T)
+            V = randn(rng, D_R, T)
+            Hv_cols = reduce(hcat, [hvp_r(X[:, t], V[:, t]) for t in 1:T])
+
+            model = DensityModel(
+                logp_r,
+                gradlogp_r,
+                D_R;
+                hvp=hvp_r,
+                logdensity_batch=logp_batch_r,
+                grad_logdensity_batch=gradlogp_batch_r,
+                hvp_batch=AutoReactant(),
+            )
+            m_p = ParallelMCMC._prepare_model(model, X[:, 1], T, nothing)
+            @test m_p.hvp_batch(X, V) ≈ Hv_cols
+        end
+
+        @testset "edge shapes" begin
+            @testset "D=1" begin
+                x1 = randn(rng, 1)
+                v1 = randn(rng, 1)
+                model = DensityModel(logp_r, AutoReactant(), 1; hvp=AutoReactant())
+                m_p = ParallelMCMC._prepare_model(model, x1, 8, nothing)
+                @test m_p.grad_logdensity(x1) ≈ gradlogp_r(x1)
+                @test m_p.hvp(x1, v1) ≈ hvp_r(x1, v1)
+            end
+
+            @testset "T=1" begin
+                T = 1
+                X = reshape(x, D_R, T)
+                V = reshape(v, D_R, T)
+                model = DensityModel(
+                    logp_r,
+                    AutoReactant(),
+                    D_R;
+                    logdensity_batch=logp_batch_r,
+                    grad_logdensity_batch=AutoReactant(),
+                    hvp=AutoReactant(),
+                    hvp_batch=AutoReactant(),
+                )
+                m_p = ParallelMCMC._prepare_model(model, x, T, nothing)
+                @test m_p.grad_logdensity_batch(X) ≈ gradlogp_batch_r(X)
+                @test m_p.hvp_batch(X, V) ≈ reshape(hvp_r(x, v), D_R, T)
+            end
+        end
+
+        @testset "Float32 on CPU" begin
+            x32 = Float32.(x)
+            v32 = Float32.(v)
+            model = DensityModel(logp_r32, AutoReactant(), D_R; hvp=AutoReactant())
+            m_p = ParallelMCMC._prepare_model(model, x32, 8, nothing)
+
+            g = m_p.grad_logdensity(x32)
+            @test eltype(g) === Float32
+            @test g ≈ gradlogp_r(x32)
+
+            Hv = m_p.hvp(x32, v32)
+            @test eltype(Hv) === Float32
+            @test Hv ≈ hvp_r(x32, v32)
+        end
+    end
+
+    @testset "documented caveat: captured data is frozen at preparation time" begin
+        data = [1.0, 1.0, 1.0, 1.0]
+        f(x) = -0.5 * sum(abs2, x .- data)
+        model = DensityModel(f, AutoReactant(), D_R)
+        m_p = ParallelMCMC._prepare_model(model, zeros(D_R))
+
+        x0 = zeros(D_R)
+        g_before = m_p.grad_logdensity(x0)
+        @test g_before ≈ [1.0, 1.0, 1.0, 1.0]
+
+        data .= 5.0
+
+        g_after = m_p.grad_logdensity(x0)
+        @test g_after ≈ [1.0, 1.0, 1.0, 1.0]
+    end
+
+    # Finite samples do not establish HVP correctness, so test the posterior and
+    # compare against an analytic HVP on the same noise tape.
+    @testset "end-to-end sampling with AutoReactant" begin
+        @testset "posterior mean recovery (standard Gaussian, mean 0)" begin
+            model = DensityModel(logp_gauss, AutoReactant(), D_R)
+            s = ParallelMALASampler(0.3; T=16, backend=AutoReactant())
+            n_samples, n_burn = 2000, 500
+            chain = sample(
+                MersenneTwister(72), model, s, n_samples; chain_type=CT_R, progress=false
+            )
+            @test size(chain) == (n_samples, 1)
+
+            xs = chain[:x]
+            @test all(x -> all(isfinite, x), xs)
+            post_mean = vec(mean(reduce(hcat, xs[(n_burn + 1):end]); dims=2))
+            @test maximum(abs, post_mean) < 0.3
+        end
+
+        @testset "matches analytic-HVP DEER on the same noise tape" begin
+            s = ParallelMALASampler(0.1; T=16, backend=AutoReactant())
+            model_r = DensityModel(logp_gauss, AutoReactant(), D_R)
+            model_an = DensityModel(logp_gauss, gradlogp_gauss, D_R; hvp=hvp_gauss)
+
+            c_r = sample(
+                MersenneTwister(99), model_r, s, 64; chain_type=CT_R, progress=false
+            )
+            c_an = sample(
+                MersenneTwister(99), model_an, s, 64; chain_type=CT_R, progress=false
+            )
+            @test c_r[:x] ≈ c_an[:x]
+        end
+    end
+
+    reactant_gpu_ok = try
+        using CUDA: CUDA
+        CUDA.functional() && (CUDA.CuArray([1.0f0]); true)
+    catch
+        false
+    end
+
+    if !reactant_gpu_ok
+        @info "Reactant HVP test: CUDA not functional — skipping CuArray boundary"
+    else
+        # This tests CuArray marshalling, not the XLA execution device.
+        @testset "CuArray boundary" begin
+            rng = MersenneTwister(73)
+            x_h = randn(rng, Float32, D_R)
+            v_h = randn(rng, Float32, D_R)
+            x_d = CUDA.CuArray(x_h)
+            v_d = CUDA.CuArray(v_h)
+
+            model = DensityModel(logp_r32, AutoReactant(), D_R; hvp=AutoReactant())
+            m_p = ParallelMCMC._prepare_model(model, x_d, 8, nothing)
+
+            g = m_p.grad_logdensity(x_d)
+            @test g isa CUDA.CuArray
+            @test Array(g) ≈ gradlogp_r(x_h)
+
+            Hv = m_p.hvp(x_d, v_d)
+            @test Hv isa CUDA.CuArray
+            @test Array(Hv) ≈ hvp_r(x_h, v_h)
+        end
+    end
+end

--- a/test/test-Reactant-Validation.jl
+++ b/test/test-Reactant-Validation.jl
@@ -1,0 +1,90 @@
+using Test
+using ParallelMCMC
+using ADTypes
+using ForwardDiff: ForwardDiff
+using LogDensityProblems: LogDensityProblems
+
+#= The AutoReactant validation in src/interface.jl needs no Reactant, so it runs
+in every test invocation. The Reactant-backed tests are opt-in in
+test-Reactant-HVP.jl. =#
+
+const DI_RV = ParallelMCMC.DEER.DI
+const D_RV = 4
+
+logp_rv(x) = -0.25 * sum(abs2, x)^2
+gradlogp_rv(x) = -sum(abs2, x) .* x
+
+struct _FakeLD_RV end
+LogDensityProblems.capabilities(::_FakeLD_RV) = LogDensityProblems.LogDensityOrder{1}()
+LogDensityProblems.dimension(::_FakeLD_RV) = D_RV
+function LogDensityProblems.logdensity_and_gradient(::_FakeLD_RV, x)
+    return logp_rv(x), gradlogp_rv(x)
+end
+
+@testset "Reactant does not pair with a DI backend" begin
+    @test ParallelMCMC._check_reactant_pair(AutoReactant(), AutoReactant()) === nothing
+    @test ParallelMCMC._check_reactant_pair(nothing, AutoReactant()) === nothing
+    @test ParallelMCMC._check_reactant_pair(AutoForwardDiff(), AutoForwardDiff()) ===
+        nothing
+
+    @test_throws ArgumentError ParallelMCMC._check_reactant_pair(
+        AutoReactant(), AutoForwardDiff()
+    )
+    @test_throws ArgumentError ParallelMCMC._check_reactant_pair(
+        AutoForwardDiff(), AutoReactant()
+    )
+end
+
+@testset "AutoReactant cannot appear inside a SecondOrder" begin
+    @test ParallelMCMC._check_reactant_pair(
+        nothing, DI_RV.SecondOrder(AutoForwardDiff(), AutoForwardDiff())
+    ) === nothing
+
+    @test_throws ArgumentError ParallelMCMC._check_reactant_pair(
+        nothing, DI_RV.SecondOrder(AutoReactant(), AutoReactant())
+    )
+    @test_throws ArgumentError ParallelMCMC._check_reactant_pair(
+        AutoForwardDiff(), DI_RV.SecondOrder(AutoReactant(), AutoForwardDiff())
+    )
+    @test_throws ArgumentError ParallelMCMC._check_reactant_pair(
+        AutoReactant(), DI_RV.SecondOrder(AutoReactant(), AutoReactant())
+    )
+end
+
+@testset "a LogDensityProblems gradient cannot pair with an AutoReactant hvp" begin
+    @test ParallelMCMC._check_reactant_hvp_source(
+        ParallelMCMC.LogDensityProblemGradient(nothing), AutoForwardDiff()
+    ) === nothing
+    @test_throws ArgumentError ParallelMCMC._check_reactant_hvp_source(
+        ParallelMCMC.LogDensityProblemGradient(nothing), AutoReactant()
+    )
+
+    model = DensityModel(_FakeLD_RV(); hvp=AutoReactant())
+    @test_throws ArgumentError ParallelMCMC._prepare_model(model, zeros(D_RV), 8, nothing)
+end
+
+@testset "mixed pairs are refused at preparation" begin
+    x = zeros(D_RV)
+
+    reactant_grad = DensityModel(logp_rv, AutoReactant(), D_RV; hvp=AutoForwardDiff())
+    @test_throws ArgumentError ParallelMCMC._prepare_model(reactant_grad, x, 8, nothing)
+
+    reactant_hvp = DensityModel(logp_rv, AutoForwardDiff(), D_RV; hvp=AutoReactant())
+    @test_throws ArgumentError ParallelMCMC._prepare_model(reactant_hvp, x, 8, nothing)
+end
+
+# The extension shadows these fallbacks once Reactant is loaded, so the check
+# only applies while it is absent.
+if Base.get_extension(ParallelMCMC, :ReactantExt) === nothing
+    @testset "clear load-hint error without Reactant loaded" begin
+        model_grad = DensityModel(logp_rv, AutoReactant(), D_RV)
+        @test_throws "AutoReactant requires Reactant.jl" ParallelMCMC._prepare_model(
+            model_grad, zeros(D_RV), 8, AutoReactant()
+        )
+
+        model_hvp = DensityModel(logp_rv, gradlogp_rv, D_RV; hvp=AutoReactant())
+        @test_throws "AutoReactant requires Reactant.jl" ParallelMCMC._prepare_model(
+            model_hvp, zeros(D_RV), 8, nothing
+        )
+    end
+end

--- a/test/test-Turing-Integration.jl
+++ b/test/test-Turing-Integration.jl
@@ -133,15 +133,7 @@ end
 end
 
 @testset "DynamicPPLExt: SecondOrder hvp on a Turing model" begin
-    #= The gradient slot of a Turing model is DynamicPPL's own AD-prepared
-    gradient, whose preparation rejects the tangents an outer pass would push
-    through it, so a plain backend in `hvp` cannot differentiate it. A
-    `SecondOrder` differentiates the log-density instead, bypassing that gradient,
-    which is what makes an AD HVP reachable for a Turing model at all.
-
-    normal_model(y) in unconstrained space is
-      logp(μ) = logpdf(Normal(0,1), μ) + logpdf(Normal(μ, 0.5), y),
-    so H = -1 - 1/0.5^2 = -5 and Hv = -5v. =#
+    # For this model, H = -1 - 1/0.5^2 = -5.
     so = ParallelMCMC.DI.SecondOrder(ADTypes.AutoForwardDiff(), ADTypes.AutoForwardDiff())
     model = DensityModel(
         normal_model(TRUE_OBS); ad_backend=ADTypes.AutoForwardDiff(), hvp=so
@@ -150,7 +142,6 @@ end
 
     prepped = ParallelMCMC._prepare_model(model, [0.0], 8, nothing)
     @test prepped.hvp([0.0], [1.0]) ≈ [-5.0]
-    # the model brought its own HVP, so no sampler backend is needed
     chain = sample(
         MersenneTwister(12),
         model,
@@ -161,10 +152,6 @@ end
     )
     @test all(isfinite, vec(chain[@varname(μ)]))
 
-    #= Preparing a plain backend succeeds, since DI only builds the pushforward
-    against the Float64 template. The first call is what fails, pushing tangents
-    into DynamicPPL's prepared gradient. Pinned so that if DynamicPPL ever lifts
-    this, the `SecondOrder`-only advice in the extension docstring is revisited. =#
     model_plain = DensityModel(
         normal_model(TRUE_OBS);
         ad_backend=ADTypes.AutoForwardDiff(),
@@ -175,10 +162,6 @@ end
 end
 
 @testset "DynamicPPLExt: batched slots reach the batched DEER path" begin
-    #= DynamicPPL supplies no batched log-density, so the batched slots are the
-    only way a Turing model reaches the batched update. Written out by hand for
-    normal_model, including the normalizing constants so that the log-densities
-    reported for a trajectory agree with `model.logdensity`. =#
     σ = 0.5
     logp_b(X) =
         vec(-0.5 .* X .^ 2 .- 0.5 .* ((TRUE_OBS .- X) ./ σ) .^ 2 .- log(2π) .- log(σ))
@@ -198,7 +181,6 @@ end
     @test model.grad_logdensity_batch === grad_b
     @test model.hvp_batch === hvp_b
 
-    # the hand-written batched log-density agrees with the model's own, column by column
     X = reshape([-0.5, 0.0, 0.7, 1.4], 1, 4)
     @test logp_b(X) ≈ [model.logdensity(X[:, t]) for t in 1:size(X, 2)]
 


### PR DESCRIPTION
Closes #59.

CUDA moves from `[deps]` to `[weakdeps]` behind a new `CUDAExt`, so installing and
loading ParallelMCMC no longer drags the CUDA stack onto machines that cannot use
it. `using ParallelMCMC` on its own now leaves CUDA unloaded; GPU runs are
unchanged apart from needing `using CUDA` alongside it, which they already did to
build the `CuArray`s in the first place.
